### PR TITLE
Accept user-facing filters directly on all endpoints

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -14,6 +14,7 @@ from routes.utils import to_date_range, to_json
 from routes.producers import producers_payload
 from data.sql.migrations.migrations import perform_all_migrations
 from utils.ranking import album_ranks_over_time, album_streams_by_month, artist_ranks_over_time, artist_streams_by_month, track_ranks_over_time, track_streams_by_month
+from utils.ranking import filtered_track_ranks_over_time, filtered_track_streams_by_month, filtered_artist_ranks_over_time, filtered_artist_streams_by_month, filtered_album_ranks_over_time, filtered_album_streams_by_month
 
 pd.options.mode.chained_assignment = None  # default='warn'
 app = Flask(__name__)
@@ -90,56 +91,74 @@ def list_release_years():
 
 @app.route("/api/streams/tracks/history", methods = ['POST'])
 def list_track_stream_history():
+    n = request.json.get('n', 10)
     track_uris = request.json.get('tracks', None)
-    if track_uris is None or len(track_uris) == 0:
-        return []
-    min_date, max_date = to_date_range(request.json.get('wrapped', None))
-    return to_json(track_ranks_over_time(track_uris, min_date, max_date))
+    if track_uris is not None:
+        if len(track_uris) == 0:
+            return []
+        min_date, max_date = to_date_range(request.json.get('wrapped', None))
+        return to_json(track_ranks_over_time(track_uris, min_date, max_date))
+    return to_json(filtered_track_ranks_over_time(request.json, n))
 
 
 @app.route("/api/streams/tracks/months", methods = ['POST'])
 def list_track_streams_by_month():
+    n = request.json.get('n', 5)
     track_uris = request.json.get('tracks', None)
-    if track_uris is None or len(track_uris) == 0:
-        return {}
-    min_date, max_date = to_date_range(request.json.get('wrapped', None))
-    return track_streams_by_month(track_uris, min_date, max_date)
+    if track_uris is not None:
+        if len(track_uris) == 0:
+            return {}
+        min_date, max_date = to_date_range(request.json.get('wrapped', None))
+        return track_streams_by_month(track_uris, min_date, max_date)
+    return filtered_track_streams_by_month(request.json, n)
 
 
 @app.route("/api/streams/artists/history", methods = ['POST'])
 def list_artist_stream_history():
+    n = request.json.get('n', 10)
     artist_uris = request.json.get('artists', None)
-    if artist_uris is None or len(artist_uris) == 0:
-        return []
-    min_date, max_date = to_date_range(request.json.get('wrapped', None))
-    return to_json(artist_ranks_over_time(artist_uris, min_date, max_date))
+    if artist_uris is not None:
+        if len(artist_uris) == 0:
+            return []
+        min_date, max_date = to_date_range(request.json.get('wrapped', None))
+        return to_json(artist_ranks_over_time(artist_uris, min_date, max_date))
+    return to_json(filtered_artist_ranks_over_time(request.json, n))
 
 
 @app.route("/api/streams/artists/months", methods = ['POST'])
 def list_artist_streams_by_month():
+    n = request.json.get('n', 5)
     artist_uris = request.json.get('artists', None)
-    if artist_uris is None or len(artist_uris) == 0:
-        return {}
-    min_date, max_date = to_date_range(request.json.get('wrapped', None))
-    return artist_streams_by_month(artist_uris, min_date, max_date)
+    if artist_uris is not None:
+        if len(artist_uris) == 0:
+            return {}
+        min_date, max_date = to_date_range(request.json.get('wrapped', None))
+        return artist_streams_by_month(artist_uris, min_date, max_date)
+    return filtered_artist_streams_by_month(request.json, n)
 
 
 @app.route("/api/streams/albums/history", methods = ['POST'])
 def list_album_stream_history():
+    n = request.json.get('n', 10)
     album_uris = request.json.get('albums', None)
-    if album_uris is None or len(album_uris) == 0:
-        return []
-    min_date, max_date = to_date_range(request.json.get('wrapped', None))
-    return to_json(album_ranks_over_time(album_uris, min_date, max_date))
+    if album_uris is not None:
+        if len(album_uris) == 0:
+            return []
+        min_date, max_date = to_date_range(request.json.get('wrapped', None))
+        return to_json(album_ranks_over_time(album_uris, min_date, max_date))
+    return to_json(filtered_album_ranks_over_time(request.json, n))
 
 
 @app.route("/api/streams/albums/months", methods = ['POST'])
 def list_album_streams_by_month():
+    n = request.json.get('n', 5)
     album_uris = request.json.get('albums', None)
-    if album_uris is None or len(album_uris) == 0:
-        return {}
-    min_date, max_date = to_date_range(request.json.get('wrapped', None))
-    return album_streams_by_month(album_uris, min_date, max_date)
+    if album_uris is not None:
+        if len(album_uris) == 0:
+            return {}
+        min_date, max_date = to_date_range(request.json.get('wrapped', None))
+        return album_streams_by_month(album_uris, min_date, max_date)
+    return filtered_album_streams_by_month(request.json, n)
 
 
 @app.route("/api/recommendations", methods = ['POST'])

--- a/app/app.py
+++ b/app/app.py
@@ -50,13 +50,12 @@ def get_track_credits(track_uri):
 
 @app.route("/api/playlists", methods = ['POST'])
 def list_playlists():
-    return playlists_payload(request.json.get('tracks', None))
+    return playlists_payload(request.json)
 
 
 @app.route("/api/artists", methods = ['POST'])
 def list_artists():
-    min_date, max_date = to_date_range(request.json.get("wrapped"))
-    return artists_payload(request.json.get('tracks', None), min_date, max_date)
+    return artists_payload(request.json)
 
 
 @app.route("/api/artists/<artist_uri>/credits")
@@ -66,28 +65,27 @@ def get_artist_credits(artist_uri):
 
 @app.route("/api/albums", methods = ['POST'])
 def list_albums():
-    min_date, max_date = to_date_range(request.json.get("wrapped"))
-    return albums_payload(request.json.get('tracks', None), min_date, max_date)
+    return albums_payload(request.json)
 
 
 @app.route("/api/labels", methods = ['POST'])
 def list_labels():
-    return labels_payload(request.json.get('tracks', None))
+    return labels_payload(request.json)
 
 
 @app.route("/api/genres", methods = ['POST'])
 def list_genres():
-    return genres_payload(request.json.get('tracks', None))
+    return genres_payload(request.json)
 
 
 @app.route("/api/producers", methods=['POST'])
 def list_producers():
-    return producers_payload(request.json.get('tracks', None))
+    return producers_payload(request.json)
 
 
 @app.route("/api/release-years", methods = ['POST'])
 def list_release_years():
-    return release_years_payload(request.json.get('tracks', None))
+    return release_years_payload(request.json)
 
 
 @app.route("/api/streams/tracks/history", methods = ['POST'])
@@ -146,4 +144,4 @@ def list_album_streams_by_month():
 
 @app.route("/api/recommendations", methods = ['POST'])
 def get_recommendations():
-    return recommendations_payload(request.json.get('tracks', None))
+    return recommendations_payload(request.json)

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -237,49 +237,49 @@ export async function getTrackCredits(uri: string): Promise<Credit[]> {
 }
 
 export async function getPlaylists(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Record<string, Playlist>> {
   return sendRequest(`/api/playlists`, "playlists", filters);
 }
 
 export async function getArtists(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Record<string, Artist>> {
   return sendRequest(`/api/artists`, "artists", filters);
 }
 
 export async function getAlbums(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Record<string, Album>> {
   return sendRequest(`/api/albums`, "albums", filters);
 }
 
 export async function getLabels(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Label[]> {
   return sendRequest(`/api/labels`, "labels", filters);
 }
 
 export async function getGenres(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Genre[]> {
   return sendRequest(`/api/genres`, "genres", filters);
 }
 
 export async function getProducers(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Record<string, Producer>> {
   return sendRequest(`/api/producers`, "producers", filters);
 }
 
 export async function getReleaseYears(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<ReleaseYear[]> {
   return sendRequest(`/api/release-years`, "release years", filters);
 }
 
 export async function getTracksStreamingHistory(
-  filters: Pick<ActiveFilters, "tracks" | "wrapped">
+  filters: ActiveFilters & { n?: number }
 ): Promise<TrackRank[]> {
   return sendRequest(
     `/api/streams/tracks/history`,
@@ -289,7 +289,7 @@ export async function getTracksStreamingHistory(
 }
 
 export async function getArtistsStreamingHistory(
-  filters: Pick<ActiveFilters, "artists" | "wrapped">
+  filters: ActiveFilters & { n?: number }
 ): Promise<ArtistRank[]> {
   return sendRequest(
     `/api/streams/artists/history`,
@@ -299,7 +299,7 @@ export async function getArtistsStreamingHistory(
 }
 
 export async function getAlbumsStreamingHistory(
-  filters: Pick<ActiveFilters, "albums" | "wrapped">
+  filters: ActiveFilters & { n?: number }
 ): Promise<AlbumRank[]> {
   return sendRequest(
     `/api/streams/albums/history`,
@@ -309,7 +309,7 @@ export async function getAlbumsStreamingHistory(
 }
 
 export async function getTracksStreamsByMonth(
-  filters: Pick<ActiveFilters, "tracks" | "wrapped">
+  filters: ActiveFilters & { n?: number }
 ): Promise<StreamsByMonth> {
   return sendRequest(
     `/api/streams/tracks/months`,
@@ -319,7 +319,7 @@ export async function getTracksStreamsByMonth(
 }
 
 export async function getArtistsStreamsByMonth(
-  filters: Pick<ActiveFilters, "artists" | "wrapped">
+  filters: ActiveFilters & { n?: number }
 ): Promise<StreamsByMonth> {
   return sendRequest(
     `/api/streams/artists/months`,
@@ -329,7 +329,7 @@ export async function getArtistsStreamsByMonth(
 }
 
 export async function getAlbumsStreamsByMonth(
-  filters: Pick<ActiveFilters, "albums" | "wrapped">
+  filters: ActiveFilters & { n?: number }
 ): Promise<StreamsByMonth> {
   return sendRequest(
     `/api/streams/albums/months`,
@@ -346,7 +346,7 @@ export interface RecommendationList {
 export type Recommendations = Record<string, RecommendationList>;
 
 export async function getRecommendations(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Recommendations> {
   return sendRequest(`/api/recommendations`, "recommendations", filters);
 }

--- a/client/src/charts/TracksStreamingHistoryStack.tsx
+++ b/client/src/charts/TracksStreamingHistoryStack.tsx
@@ -3,16 +3,16 @@ import { useState } from "react";
 import { Track } from "../api";
 import { ChartSkeleton } from "../design/ChartSkeleton";
 import { mostStreamedTracks } from "../sorting";
-import { useTracksCount, useTracksStreamsByMonth } from "../useApi";
+import { useTracksCount, useTracksStreamsByMonth, useTracks } from "../useApi";
 import styles from "./StreamingHistoryItem.module.css";
 import { StreamingHistoryStack } from "./StreamingHistoryStack";
 
 export function TracksStreamingHistoryStack() {
   const [n, setN] = useState(5);
   const { data: trackCount } = useTracksCount();
+  const { data: tracks } = useTracks();
   const {
     data: streamsByMonth,
-    tracks,
     shouldRender,
   } = useTracksStreamsByMonth(n);
 

--- a/client/src/useApi.ts
+++ b/client/src/useApi.ts
@@ -2,11 +2,17 @@ import { useQuery } from "@tanstack/react-query";
 
 import {
   ActiveFilters,
+  Album,
   AlbumRank,
+  Artist,
   ArtistCreditsData,
   ArtistRank,
   Credit,
   FilterOptions,
+  Genre,
+  Label,
+  Playlist,
+  Producer,
   getAlbums,
   getAlbumsStreamingHistory,
   getAlbumsStreamsByMonth,
@@ -26,17 +32,14 @@ import {
   getTracksStreamingHistory,
   getTracksStreamsByMonth,
   Recommendations,
+  ReleaseYear,
   searchTracks,
+  StreamsByMonth,
   toFiltersQuery,
   Track,
   TrackDetails,
   TrackRank,
 } from "./api";
-import {
-  mostStreamedAlbums,
-  mostStreamedArtists,
-  mostStreamedTracks,
-} from "./sorting";
 import { useFilters } from "./useFilters";
 import { countUniqueAsOfDates, countUniqueMonths } from "./utils";
 
@@ -96,11 +99,25 @@ export function useTrackCredits(uri: string) {
 }
 
 export function usePlaylists(filters?: ActiveFilters) {
-  return useTracksDependentQuery("playlists", getPlaylists, {}, filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<Record<string, Playlist>>({
+    ...defaultQueryOptions,
+    queryKey: ["playlists", query],
+    queryFn: async () => getPlaylists(activeFilters),
+  });
 }
 
 export function useArtists(filters?: ActiveFilters) {
-  return useTracksDependentQuery("artists", getArtists, {}, filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<Record<string, Artist>>({
+    ...defaultQueryOptions,
+    queryKey: ["artists", query],
+    queryFn: async () => getArtists(activeFilters),
+  });
 }
 
 export function useArtistCredits(artistUri: string) {
@@ -112,41 +129,67 @@ export function useArtistCredits(artistUri: string) {
 }
 
 export function useAlbums(filters?: ActiveFilters) {
-  return useTracksDependentQuery("albums", getAlbums, {}, filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<Record<string, Album>>({
+    ...defaultQueryOptions,
+    queryKey: ["albums", query],
+    queryFn: async () => getAlbums(activeFilters),
+  });
 }
 
 export function useLabels(filters?: ActiveFilters) {
-  return useTracksDependentQuery("labels", getLabels, [], filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<Label[]>({
+    ...defaultQueryOptions,
+    queryKey: ["labels", query],
+    queryFn: async () => getLabels(activeFilters),
+  });
 }
 
 export function useGenres(filters?: ActiveFilters) {
-  return useTracksDependentQuery("genres", getGenres, [], filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<Genre[]>({
+    ...defaultQueryOptions,
+    queryKey: ["genres", query],
+    queryFn: async () => getGenres(activeFilters),
+  });
 }
 
 export function useReleaseYears(filters?: ActiveFilters) {
-  return useTracksDependentQuery("release-years", getReleaseYears, [], filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<ReleaseYear[]>({
+    ...defaultQueryOptions,
+    queryKey: ["release-years", query],
+    queryFn: async () => getReleaseYears(activeFilters),
+  });
 }
 
 export function useProducers(filters?: ActiveFilters) {
-  return useTracksDependentQuery("producers", getProducers, {}, filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<Record<string, Producer>>({
+    ...defaultQueryOptions,
+    queryKey: ["producers", query],
+    queryFn: async () => getProducers(activeFilters),
+  });
 }
 
 export function useTracksStreamingHistory() {
   const filters = useFilters();
-  const { data: tracks } = useTracks();
-
-  const topTenUris = Object.values(tracks ?? {})
-    .sort(mostStreamedTracks)
-    .slice(0, 10)
-    .map((t) => t.track_uri);
-
-  const tracksFilter = { tracks: topTenUris, wrapped: filters.wrapped };
-  const query = toFiltersQuery(tracksFilter);
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
   const result = useQuery<TrackRank[]>({
     ...defaultQueryOptions,
     queryKey: ["tracks-streaming-history", query],
-    enabled: !!tracks,
-    queryFn: async () => getTracksStreamingHistory(tracksFilter),
+    queryFn: async () => getTracksStreamingHistory({ ...filters, n: 10 }),
   });
 
   const shouldRender = !result.data || countUniqueAsOfDates(result.data) > 4;
@@ -156,20 +199,11 @@ export function useTracksStreamingHistory() {
 
 export function useArtistsStreamingHistory() {
   const filters = useFilters();
-  const { data: artists } = useArtists();
-
-  const topTenUris = Object.values(artists ?? {})
-    .sort(mostStreamedArtists)
-    .slice(0, 10)
-    .map((t) => t.artist_uri);
-
-  const artistsFilter = { artists: topTenUris, wrapped: filters.wrapped };
-  const query = toFiltersQuery(artistsFilter);
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
   const result = useQuery<ArtistRank[]>({
     ...defaultQueryOptions,
     queryKey: ["artists-streaming-history", query],
-    enabled: !!artists,
-    queryFn: async () => getArtistsStreamingHistory(artistsFilter),
+    queryFn: async () => getArtistsStreamingHistory({ ...filters, n: 10 }),
   });
 
   const shouldRender = !result.data || countUniqueAsOfDates(result.data) > 4;
@@ -179,20 +213,11 @@ export function useArtistsStreamingHistory() {
 
 export function useAlbumsStreamingHistory() {
   const filters = useFilters();
-  const { data: albums } = useAlbums();
-
-  const topTenUris = Object.values(albums ?? {})
-    .sort(mostStreamedAlbums)
-    .slice(0, 10)
-    .map((t) => t.album_uri);
-
-  const albumsFilter = { albums: topTenUris, wrapped: filters.wrapped };
-  const query = toFiltersQuery(albumsFilter);
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
   const result = useQuery<AlbumRank[]>({
     ...defaultQueryOptions,
     queryKey: ["albums-streaming-history", query],
-    enabled: !!albums,
-    queryFn: async () => getAlbumsStreamingHistory(albumsFilter),
+    queryFn: async () => getAlbumsStreamingHistory({ ...filters, n: 10 }),
   });
 
   const shouldRender = !result.data || countUniqueAsOfDates(result.data) > 4;
@@ -201,22 +226,13 @@ export function useAlbumsStreamingHistory() {
 }
 
 export function useTracksStreamsByMonth(n: number = 5) {
-  function getTopNTracksStreamsByMonth(
-    filters: ActiveFilters,
-    tracks: Record<string, Track>
-  ) {
-    const topNUris = Object.values(tracks ?? {})
-      .sort(mostStreamedTracks)
-      .slice(0, n)
-      .map((t) => t.track_uri);
-    return getTracksStreamsByMonth({ ...filters, tracks: topNUris });
-  }
-
-  const result = useTracksDependentQuery(
-    "tracks-streams-by-month-" + n,
-    getTopNTracksStreamsByMonth,
-    {}
-  );
+  const filters = useFilters();
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
+  const result = useQuery<StreamsByMonth>({
+    ...defaultQueryOptions,
+    queryKey: ["tracks-streams-by-month", query, n],
+    queryFn: async () => getTracksStreamsByMonth({ ...filters, n }),
+  });
 
   const shouldRender = !result.data || countUniqueMonths(result.data) > 3;
 
@@ -225,22 +241,11 @@ export function useTracksStreamsByMonth(n: number = 5) {
 
 export function useArtistsStreamsByMonth(n: number = 5) {
   const filters = useFilters();
-  const { data: artists } = useArtists();
-
-  const topNUris = Object.values(artists ?? {})
-    .sort(mostStreamedArtists)
-    .slice(0, n)
-    .map((t) => t.artist_uri);
-
-  const artistsFilter = { artists: topNUris, wrapped: filters.wrapped };
-  const query = toFiltersQuery(artistsFilter);
-  const result = useQuery<
-    Record<string, Record<number, Record<number, number>>>
-  >({
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
+  const result = useQuery<StreamsByMonth>({
     ...defaultQueryOptions,
     queryKey: ["artists-streams-by-month", query, n],
-    enabled: !!artists,
-    queryFn: async () => getArtistsStreamsByMonth(artistsFilter),
+    queryFn: async () => getArtistsStreamsByMonth({ ...filters, n }),
   });
 
   const shouldRender = !result.data || countUniqueMonths(result.data) > 3;
@@ -250,22 +255,11 @@ export function useArtistsStreamsByMonth(n: number = 5) {
 
 export function useAlbumsStreamsByMonth(n: number = 5) {
   const filters = useFilters();
-  const { data: albums } = useAlbums();
-
-  const topNUris = Object.values(albums ?? {})
-    .sort(mostStreamedAlbums)
-    .slice(0, n)
-    .map((t) => t.album_uri);
-
-  const albumsFilter = { albums: topNUris, wrapped: filters.wrapped };
-  const query = toFiltersQuery(albumsFilter);
-  const result = useQuery<
-    Record<string, Record<number, Record<number, number>>>
-  >({
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
+  const result = useQuery<StreamsByMonth>({
     ...defaultQueryOptions,
     queryKey: ["albums-streams-by-month", query, n],
-    enabled: !!albums,
-    queryFn: async () => getAlbumsStreamsByMonth(albumsFilter),
+    queryFn: async () => getAlbumsStreamsByMonth({ ...filters, n }),
   });
 
   const shouldRender = !result.data || countUniqueMonths(result.data) > 3;
@@ -275,63 +269,12 @@ export function useAlbumsStreamsByMonth(n: number = 5) {
 
 export function useRecommendations() {
   const filters = useFilters();
-  const query = toFiltersQuery({ wrapped: filters.wrapped, ...filters }) || DEFAULT_QUERY_KEY;
-
-  const { data: tracks, isSuccess } = useTracks(filters);
-  
-  // When no filters are applied, don't pass track URIs to avoid performance issues
-  // The server will handle unfiltered queries more efficiently without URIs
-  const hasFilters = Object.keys(filters).length > 0;
-  const tracksFilter = {
-    tracks: hasFilters ? (tracks ? Object.keys(tracks) : []) : undefined,
-    wrapped: filters.wrapped,
-  };
-
-  const result = useQuery<Recommendations>({
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
+  return useQuery<Recommendations>({
     ...defaultQueryOptions,
-    enabled: isSuccess,
     queryKey: ["recommendations", query],
-    queryFn: async () =>
-      hasFilters && tracksFilter.tracks && tracksFilter.tracks.length === 0
-        ? {}
-        : getRecommendations(tracksFilter),
+    queryFn: async () => getRecommendations(filters),
   });
-
-  return { ...result, tracks };
-}
-
-function useTracksDependentQuery<T>(
-  key: string,
-  getValue: (
-    filters: ActiveFilters,
-    tracks: Record<string, Track>
-  ) => Promise<T>,
-  defaultValue: T,
-  filters?: ActiveFilters
-) {
-  const globalFilters = useFilters();
-  filters ??= globalFilters;
-  const query =
-    toFiltersQuery({ wrapped: filters.wrapped, ...filters }) ||
-    DEFAULT_QUERY_KEY;
-
-  const { data: tracks, isSuccess } = useTracks(filters);
-  const tracksFilter = {
-    tracks: tracks ? Object.keys(tracks) : [],
-    wrapped: filters.wrapped,
-  };
-
-  const result = useQuery<T>({
-    ...defaultQueryOptions,
-    enabled: isSuccess,
-    queryKey: [key, query],
-    queryFn: async () =>
-      tracksFilter.tracks.length === 0
-        ? defaultValue
-        : getValue(tracksFilter, tracks!),
-  });
-
-  return { ...result, tracks };
 }
 
 // If a piece of a query key is an empty string, the request will not fire

--- a/data/filters.py
+++ b/data/filters.py
@@ -1,0 +1,81 @@
+import typing
+from contextlib import contextmanager
+
+import sqlalchemy
+
+from data.query import query_text
+from data.raw import get_engine
+from routes.utils import to_date_range
+
+
+def parse_filters(request_json: dict) -> dict:
+    """Parse a request JSON body into the standard filter parameter dict for SQL queries."""
+    if request_json is None:
+        request_json = {}
+
+    min_stream_date, max_stream_date = to_date_range(request_json.get("wrapped"))
+
+    tracks = request_json.get('tracks', None)
+    playlists = request_json.get('playlists', None)
+    artists = request_json.get('artists', None)
+    albums = request_json.get('albums', None)
+    labels = request_json.get('labels', None)
+    genres = request_json.get('genres', None)
+    producers = request_json.get('producers', None)
+    years = request_json.get('years', None)
+    liked = request_json.get('liked', None)
+
+    return {
+        "filter_tracks": tracks is not None,
+        "track_uris": _to_tuple(tracks, 'EMPTY'),
+        "liked": bool(liked),
+        "filter_playlists": playlists is not None,
+        "playlist_uris": _to_tuple(playlists, 'EMPTY'),
+        "filter_artists": artists is not None,
+        "artist_uris": _to_tuple(artists, 'EMPTY'),
+        "filter_albums": albums is not None,
+        "album_uris": _to_tuple(albums, 'EMPTY'),
+        "filter_labels": labels is not None,
+        "labels": _to_tuple(labels, 'EMPTY'),
+        "filter_genres": genres is not None,
+        "genres": _to_tuple(genres, 'EMPTY'),
+        "filter_producers": producers is not None,
+        "producers": _to_tuple(producers, 'EMPTY'),
+        "filter_years": years is not None,
+        "years": _to_tuple(years, 0),
+        "wrapped_start_date": min_stream_date,
+        "wrapped_end_date": max_stream_date,
+    }
+
+
+def create_matching_tracks_table(conn, params: dict):
+    """Create the matching_track_uris temp table using a SQLAlchemy connection.
+    
+    Must be called within a connection context (e.g. `with engine.begin() as conn`).
+    The temp table persists for the duration of that connection/transaction.
+    """
+    conn.execute(
+        sqlalchemy.text(query_text('create_matching_track_uris')),
+        params
+    )
+
+
+@contextmanager
+def filtered_connection(filters: dict):
+    """Context manager that yields a SQLAlchemy connection with matching_track_uris populated.
+    
+    Usage:
+        with filtered_connection(request.json) as (conn, params):
+            result = pd.read_sql_query(sqlalchemy.text(query), conn)
+    """
+    params = parse_filters(filters)
+    with get_engine().begin() as conn:
+        create_matching_tracks_table(conn, params)
+        yield conn, params
+
+
+def _to_tuple(value: typing.Optional[typing.Iterable], empty_sentinel) -> tuple:
+    if value is None or len(value) == 0:
+        return (empty_sentinel,)
+    return tuple(value)
+

--- a/data/provider.py
+++ b/data/provider.py
@@ -2,10 +2,46 @@ import typing
 import pandas as pd
 import sqlalchemy
 
+from data.filters import create_matching_tracks_table
 from data.query import query_text
 from data.raw import RawData, get_engine
 from utils.util import first
 from utils.artist_relationship import producer_credit_types
+
+
+def _to_tuple(value, empty_sentinel='EMPTY'):
+    if value is None or len(value) == 0:
+        return (empty_sentinel,)
+    return tuple(value)
+
+
+def _matching_tracks_params(
+    track_uris=None, playlist_uris=None, artist_uris=None, album_uris=None,
+    labels=None, genres=None, producers=None, years=None, liked=None,
+    start_date=None, end_date=None
+):
+    """Build the params dict for create_matching_track_uris.sql from individual arguments."""
+    return {
+        "filter_tracks": track_uris is not None,
+        "track_uris": _to_tuple(track_uris),
+        "liked": bool(liked),
+        "filter_playlists": playlist_uris is not None,
+        "playlist_uris": _to_tuple(playlist_uris),
+        "filter_artists": artist_uris is not None,
+        "artist_uris": _to_tuple(artist_uris),
+        "filter_albums": album_uris is not None,
+        "album_uris": _to_tuple(album_uris),
+        "filter_labels": labels is not None,
+        "labels": _to_tuple(labels),
+        "filter_genres": genres is not None,
+        "genres": _to_tuple(genres),
+        "filter_producers": producers is not None,
+        "producers": _to_tuple(producers),
+        "filter_years": years is not None,
+        "years": _to_tuple(years, 0),
+        "wrapped_start_date": start_date,
+        "wrapped_end_date": end_date,
+    }
 
 class DataProvider:
     _instance = None
@@ -85,10 +121,8 @@ class DataProvider:
 
     def playlists(self, track_uris: str = None) -> pd.DataFrame:
         with get_engine().begin() as conn:
-            return pd.read_sql_query(sqlalchemy.text(query_text('select_playlists')), conn, params={
-                "filter_tracks": track_uris is not None,
-                "track_uris": tuple(['EMPTY']) if track_uris is None or len(track_uris) == 0 else tuple(track_uris)
-            })
+            create_matching_tracks_table(conn, _matching_tracks_params(track_uris=track_uris))
+            return pd.read_sql_query(sqlalchemy.text(query_text('select_playlists')), conn)
 
 
     def albums(self, 
@@ -96,9 +130,8 @@ class DataProvider:
                start_date: str = None,
                end_date: str = None) -> pd.DataFrame:
         with get_engine().begin() as conn:
+            create_matching_tracks_table(conn, _matching_tracks_params(track_uris=track_uris, start_date=start_date, end_date=end_date))
             albums = pd.read_sql_query(sqlalchemy.text(query_text('select_albums')), conn, params={
-                "filter_tracks": track_uris is not None,
-                "track_uris": tuple(['EMPTY']) if track_uris is None or len(track_uris) == 0 else tuple(track_uris),
                 "wrapped_start_date": start_date,
                 "wrapped_end_date": end_date
             })
@@ -199,13 +232,12 @@ class DataProvider:
                 start_date: str = None,
                 end_date: str = None):
         with get_engine().begin() as conn:
+            create_matching_tracks_table(conn, _matching_tracks_params(track_uris=track_uris, start_date=start_date, end_date=end_date))
             return pd.read_sql_query(sqlalchemy.text(query_text('select_artists')), conn, params={
-                "filter_tracks": track_uris is not None,
-                "track_uris": tuple(['EMPTY']) if track_uris is None or len(track_uris) == 0 else tuple(track_uris),
                 "filter_artists": uris is not None,
-                "artist_uris": tuple(['EMPTY']) if uris is None or len(uris) == 0 else tuple(uris),
+                "artist_uris": _to_tuple(uris),
                 "filter_mbids": mbids is not None,
-                "mbids": tuple(['EMPTY']) if mbids is None or len(mbids) == 0 else tuple(mbids),
+                "mbids": _to_tuple(mbids),
                 "wrapped_start_date": start_date,
                 "wrapped_end_date": end_date
             })
@@ -241,10 +273,8 @@ class DataProvider:
 
     def producers(self, track_uris: typing.Iterable[str] = None) -> pd.DataFrame:
         with get_engine().begin() as conn:
-            producers = pd.read_sql_query(sqlalchemy.text(query_text('select_producers')), conn, params={
-                "filter_tracks": track_uris is not None,
-                "track_uris": tuple(['EMPTY']) if track_uris is None or len(track_uris) == 0 else tuple(track_uris)
-            })
+            create_matching_tracks_table(conn, _matching_tracks_params(track_uris=track_uris))
+            producers = pd.read_sql_query(sqlalchemy.text(query_text('select_producers')), conn)
             producers.drop_duplicates(subset=['producer_mbid'], keep='first', inplace=True)
             return producers
 

--- a/data/sql/queries/create_matching_track_uris.sql
+++ b/data/sql/queries/create_matching_track_uris.sql
@@ -1,0 +1,53 @@
+DROP TABLE IF EXISTS matching_track_uris;
+
+CREATE TEMPORARY TABLE matching_track_uris AS
+SELECT DISTINCT t.uri AS track_uri
+FROM track t
+    INNER JOIN playlist_track pt ON pt.track_uri = t.uri
+    INNER JOIN album al ON al.uri = t.album_uri
+    INNER JOIN track_artist ta ON ta.track_uri = t.uri
+    INNER JOIN artist a ON a.uri = ta.artist_uri
+    LEFT JOIN artist_genre ag ON ag.artist_uri = a.uri
+    LEFT JOIN record_label rl ON rl.album_uri = t.album_uri
+    LEFT JOIN sp_track_mb_recording stmr ON stmr.spotify_track_uri = t.uri
+    LEFT JOIN mb_recording_credit rc ON rc.recording_mbid = stmr.recording_mbid
+    LEFT JOIN (
+        SELECT s.track_uri, COUNT(*) AS stream_count
+        FROM track_stream s
+        WHERE 
+            (:wrapped_start_date IS NULL OR :wrapped_start_date <= s.played_at)
+            AND 
+            (:wrapped_end_date IS NULL OR :wrapped_end_date >= s.played_at)
+        GROUP BY s.track_uri
+    ) sc ON sc.track_uri = t.uri
+WHERE
+    (:filter_tracks = FALSE OR t.uri IN :track_uris)
+    AND
+    (:liked = FALSE OR t.uri IN (SELECT track_uri FROM liked_track))
+    AND
+    (:filter_playlists = FALSE OR pt.playlist_uri IN :playlist_uris)
+    AND
+    (:filter_artists = FALSE OR a.uri IN :artist_uris)
+    AND
+    (:filter_albums = FALSE OR al.uri IN :album_uris)
+    AND
+    (:filter_labels = FALSE OR rl.standardized_label IN (:labels))
+    AND
+    (:filter_genres = FALSE OR ag.genre IN (:genres))
+    AND
+    (:filter_producers = FALSE OR rc.artist_mbid IN (:producers))
+    AND
+    ((:wrapped_start_date IS NULL AND :wrapped_end_date IS NULL) OR sc.stream_count IS NOT NULL)
+    AND
+    (:filter_years = FALSE OR (
+        CASE
+        WHEN LENGTH(al.release_date) = 10
+            THEN EXTRACT(YEAR FROM TO_DATE(al.release_date, 'YYYY-MM-DD'))
+        WHEN LENGTH(al.release_date) = 7
+            THEN EXTRACT(YEAR FROM TO_DATE(al.release_date, 'YYYY-MM'))
+        WHEN LENGTH(al.release_date) = 4
+            THEN EXTRACT(YEAR FROM TO_DATE(al.release_date, 'YYYY'))
+        ELSE 0
+        END
+        ) IN :years
+    );

--- a/data/sql/queries/filtered_album_ranks_over_time.sql
+++ b/data/sql/queries/filtered_album_ranks_over_time.sql
@@ -1,0 +1,38 @@
+WITH top_albums AS (
+    SELECT t.album_uri, COUNT(*) AS total_streams
+    FROM track_stream s
+    INNER JOIN track t ON t.uri = s.track_uri
+    WHERE s.track_uri IN (SELECT track_uri FROM matching_track_uris)
+        AND (:from_date IS NULL OR s.played_at >= :from_date)
+        AND (:to_date IS NULL OR s.played_at <= :to_date)
+    GROUP BY t.album_uri
+    ORDER BY total_streams DESC
+    LIMIT :n
+),
+month_ends AS (
+    SELECT DISTINCT DATE_TRUNC('month', s.played_at) + INTERVAL '1 month' - INTERVAL '1 second' AS as_of_date
+    FROM track_stream s
+    INNER JOIN track t ON t.uri = s.track_uri
+    WHERE t.album_uri IN (SELECT album_uri FROM top_albums)
+        AND (:from_date IS NULL OR s.played_at >= :from_date)
+        AND (:to_date IS NULL OR s.played_at <= :to_date)
+),
+cumulative_counts AS (
+    SELECT 
+        t.album_uri,
+        m.as_of_date,
+        COUNT(*) AS album_stream_count
+    FROM track_stream s
+    INNER JOIN track t ON t.uri = s.track_uri
+    CROSS JOIN month_ends m
+    WHERE t.album_uri IN (SELECT album_uri FROM top_albums)
+        AND s.played_at <= m.as_of_date
+    GROUP BY t.album_uri, m.as_of_date
+)
+SELECT 
+    album_uri,
+    0 AS album_rank,
+    album_stream_count,
+    as_of_date
+FROM cumulative_counts
+ORDER BY album_uri, as_of_date;

--- a/data/sql/queries/filtered_album_streams_by_month.sql
+++ b/data/sql/queries/filtered_album_streams_by_month.sql
@@ -1,0 +1,22 @@
+WITH top_albums AS (
+    SELECT t.album_uri, COUNT(*) AS total_streams
+    FROM track_stream s
+    INNER JOIN track t ON t.uri = s.track_uri
+    WHERE s.track_uri IN (SELECT track_uri FROM matching_track_uris)
+        AND (:from_date IS NULL OR s.played_at >= :from_date)
+        AND (:to_date IS NULL OR s.played_at <= :to_date)
+    GROUP BY t.album_uri
+    ORDER BY total_streams DESC
+    LIMIT :n
+)
+SELECT 
+    t.album_uri,
+    EXTRACT(YEAR FROM s.played_at)::INTEGER AS year,
+    EXTRACT(MONTH FROM s.played_at)::INTEGER AS month,
+    COUNT(*) AS stream_count
+FROM track_stream s
+INNER JOIN track t ON t.uri = s.track_uri
+WHERE t.album_uri IN (SELECT album_uri FROM top_albums)
+    AND (:from_date IS NULL OR s.played_at >= :from_date)
+    AND (:to_date IS NULL OR s.played_at <= :to_date)
+GROUP BY t.album_uri, year, month;

--- a/data/sql/queries/filtered_artist_ranks_over_time.sql
+++ b/data/sql/queries/filtered_artist_ranks_over_time.sql
@@ -1,0 +1,38 @@
+WITH top_artists AS (
+    SELECT ta.artist_uri, COUNT(*) AS total_streams
+    FROM track_stream s
+    INNER JOIN track_artist ta ON ta.track_uri = s.track_uri
+    WHERE s.track_uri IN (SELECT track_uri FROM matching_track_uris)
+        AND (:from_date IS NULL OR s.played_at >= :from_date)
+        AND (:to_date IS NULL OR s.played_at <= :to_date)
+    GROUP BY ta.artist_uri
+    ORDER BY total_streams DESC
+    LIMIT :n
+),
+month_ends AS (
+    SELECT DISTINCT DATE_TRUNC('month', s.played_at) + INTERVAL '1 month' - INTERVAL '1 second' AS as_of_date
+    FROM track_stream s
+    INNER JOIN track_artist ta ON ta.track_uri = s.track_uri
+    WHERE ta.artist_uri IN (SELECT artist_uri FROM top_artists)
+        AND (:from_date IS NULL OR s.played_at >= :from_date)
+        AND (:to_date IS NULL OR s.played_at <= :to_date)
+),
+cumulative_counts AS (
+    SELECT 
+        ta.artist_uri,
+        m.as_of_date,
+        COUNT(*) AS artist_stream_count
+    FROM track_stream s
+    INNER JOIN track_artist ta ON ta.track_uri = s.track_uri
+    CROSS JOIN month_ends m
+    WHERE ta.artist_uri IN (SELECT artist_uri FROM top_artists)
+        AND s.played_at <= m.as_of_date
+    GROUP BY ta.artist_uri, m.as_of_date
+)
+SELECT 
+    artist_uri,
+    0 AS artist_rank,
+    artist_stream_count,
+    as_of_date
+FROM cumulative_counts
+ORDER BY artist_uri, as_of_date;

--- a/data/sql/queries/filtered_artist_streams_by_month.sql
+++ b/data/sql/queries/filtered_artist_streams_by_month.sql
@@ -1,0 +1,22 @@
+WITH top_artists AS (
+    SELECT ta.artist_uri, COUNT(*) AS total_streams
+    FROM track_stream s
+    INNER JOIN track_artist ta ON ta.track_uri = s.track_uri
+    WHERE s.track_uri IN (SELECT track_uri FROM matching_track_uris)
+        AND (:from_date IS NULL OR s.played_at >= :from_date)
+        AND (:to_date IS NULL OR s.played_at <= :to_date)
+    GROUP BY ta.artist_uri
+    ORDER BY total_streams DESC
+    LIMIT :n
+)
+SELECT 
+    ta.artist_uri,
+    EXTRACT(YEAR FROM s.played_at)::INTEGER AS year,
+    EXTRACT(MONTH FROM s.played_at)::INTEGER AS month,
+    COUNT(*) AS stream_count
+FROM track_stream s
+INNER JOIN track_artist ta ON ta.track_uri = s.track_uri
+WHERE ta.artist_uri IN (SELECT artist_uri FROM top_artists)
+    AND (:from_date IS NULL OR s.played_at >= :from_date)
+    AND (:to_date IS NULL OR s.played_at <= :to_date)
+GROUP BY ta.artist_uri, year, month;

--- a/data/sql/queries/filtered_track_ranks_over_time.sql
+++ b/data/sql/queries/filtered_track_ranks_over_time.sql
@@ -1,0 +1,35 @@
+WITH top_tracks AS (
+    SELECT s.track_uri, COUNT(*) AS total_streams
+    FROM track_stream s
+    WHERE s.track_uri IN (SELECT track_uri FROM matching_track_uris)
+        AND (:from_date IS NULL OR s.played_at >= :from_date)
+        AND (:to_date IS NULL OR s.played_at <= :to_date)
+    GROUP BY s.track_uri
+    ORDER BY total_streams DESC
+    LIMIT :n
+),
+month_ends AS (
+    SELECT DISTINCT DATE_TRUNC('month', played_at) + INTERVAL '1 month' - INTERVAL '1 second' AS as_of_date
+    FROM track_stream
+    WHERE track_uri IN (SELECT track_uri FROM top_tracks)
+        AND (:from_date IS NULL OR played_at >= :from_date)
+        AND (:to_date IS NULL OR played_at <= :to_date)
+),
+cumulative_counts AS (
+    SELECT 
+        s.track_uri,
+        m.as_of_date,
+        COUNT(*) AS track_stream_count
+    FROM track_stream s
+    CROSS JOIN month_ends m
+    WHERE s.track_uri IN (SELECT track_uri FROM top_tracks)
+        AND s.played_at <= m.as_of_date
+    GROUP BY s.track_uri, m.as_of_date
+)
+SELECT 
+    track_uri,
+    0 AS track_rank,
+    track_stream_count,
+    as_of_date
+FROM cumulative_counts
+ORDER BY track_uri, as_of_date;

--- a/data/sql/queries/filtered_track_streams_by_month.sql
+++ b/data/sql/queries/filtered_track_streams_by_month.sql
@@ -1,0 +1,20 @@
+WITH top_tracks AS (
+    SELECT s.track_uri, COUNT(*) AS total_streams
+    FROM track_stream s
+    WHERE s.track_uri IN (SELECT track_uri FROM matching_track_uris)
+        AND (:from_date IS NULL OR s.played_at >= :from_date)
+        AND (:to_date IS NULL OR s.played_at <= :to_date)
+    GROUP BY s.track_uri
+    ORDER BY total_streams DESC
+    LIMIT :n
+)
+SELECT 
+    s.track_uri,
+    EXTRACT(YEAR FROM s.played_at)::INTEGER AS year,
+    EXTRACT(MONTH FROM s.played_at)::INTEGER AS month,
+    COUNT(*) AS stream_count
+FROM track_stream s
+WHERE s.track_uri IN (SELECT track_uri FROM top_tracks)
+    AND (:from_date IS NULL OR s.played_at >= :from_date)
+    AND (:to_date IS NULL OR s.played_at <= :to_date)
+GROUP BY s.track_uri, year, month;

--- a/data/sql/queries/select_album_recommendations_rediscover.sql
+++ b/data/sql/queries/select_album_recommendations_rediscover.sql
@@ -1,6 +1,6 @@
 -- Find albums with significant listening history that haven't been played recently
 -- Only considers albums with at least 2 tracks with listens
--- Parameters: :percentile (0.0 to 1.0), :filter_tracks (boolean), :track_uris (array)
+-- Parameters: percentile (0.0 to 1.0), filter_tracks (boolean)
 WITH album_stats AS (
     SELECT 
         t.album_uri,

--- a/data/sql/queries/select_album_recommendations_rediscover.sql
+++ b/data/sql/queries/select_album_recommendations_rediscover.sql
@@ -9,7 +9,7 @@ WITH album_stats AS (
         MAX(s.played_at) AS last_played
     FROM track_stream s
     INNER JOIN track t ON t.uri = s.track_uri
-    WHERE (:filter_tracks = FALSE OR s.track_uri IN :track_uris)
+    WHERE (:filter_tracks = FALSE OR s.track_uri IN (SELECT track_uri FROM matching_track_uris))
     GROUP BY t.album_uri
     HAVING COUNT(DISTINCT s.track_uri) >= 2
 ),

--- a/data/sql/queries/select_albums.sql
+++ b/data/sql/queries/select_albums.sql
@@ -28,7 +28,7 @@ SELECT
             FROM track it 
             INNER JOIN liked_track ilt ON ilt.track_uri = it.uri
             WHERE it.album_uri = al.uri
-            AND (:filter_tracks = FALSE OR it.uri IN :track_uris)
+            AND it.uri IN (SELECT track_uri FROM matching_track_uris)
         )
     ) AS album_liked_track_count,
     (
@@ -37,7 +37,7 @@ SELECT
             SELECT DISTINCT it.uri
             FROM track it 
             WHERE it.album_uri = al.uri
-            AND (:filter_tracks = FALSE OR it.uri IN :track_uris)
+            AND it.uri IN (SELECT track_uri FROM matching_track_uris)
         )
     ) AS album_track_count,
     (
@@ -54,7 +54,7 @@ SELECT
 FROM album al
     INNER JOIN track t ON t.album_uri = al.uri
     LEFT JOIN tmp_album_stream_counts sc ON sc.album_uri = al.uri
-WHERE (:filter_tracks = FALSE OR t.uri IN :track_uris)
+WHERE t.uri IN (SELECT track_uri FROM matching_track_uris)
 GROUP BY 
     al.uri,
     al.name,

--- a/data/sql/queries/select_artist_recommendations_rediscover.sql
+++ b/data/sql/queries/select_artist_recommendations_rediscover.sql
@@ -7,7 +7,7 @@ WITH artist_stats AS (
         MAX(s.played_at) AS last_played
     FROM track_stream s
     INNER JOIN track_artist ta ON ta.track_uri = s.track_uri
-    WHERE (:filter_tracks = FALSE OR s.track_uri IN :track_uris)
+    WHERE (:filter_tracks = FALSE OR s.track_uri IN (SELECT track_uri FROM matching_track_uris))
     GROUP BY ta.artist_uri
 ),
 stream_percentiles AS (

--- a/data/sql/queries/select_artist_recommendations_rediscover.sql
+++ b/data/sql/queries/select_artist_recommendations_rediscover.sql
@@ -1,5 +1,5 @@
 -- Find artists with significant listening history that haven't been played recently
--- Parameters: :percentile (0.0 to 1.0), :filter_tracks (boolean), :track_uris (array)
+-- Parameters: percentile (0.0 to 1.0), filter_tracks (boolean)
 WITH artist_stats AS (
     SELECT 
         ta.artist_uri,

--- a/data/sql/queries/select_artists.sql
+++ b/data/sql/queries/select_artists.sql
@@ -37,7 +37,7 @@ SELECT
             FROM track_artist ita 
             INNER JOIN liked_track ilt ON ilt.track_uri = ita.track_uri
             WHERE ita.artist_uri = a.uri
-            AND (:filter_tracks = FALSE OR ita.track_uri IN :track_uris)
+            AND ita.track_uri IN (SELECT track_uri FROM matching_track_uris)
         )
     ) AS artist_liked_track_count,
     (
@@ -57,7 +57,7 @@ SELECT
             SELECT DISTINCT ita.track_uri
             FROM track_artist ita 
             WHERE ita.artist_uri = a.uri
-            AND (:filter_tracks = FALSE OR ita.track_uri IN :track_uris)
+            AND ita.track_uri IN (SELECT track_uri FROM matching_track_uris)
         )
     ) AS artist_track_count
 
@@ -70,7 +70,7 @@ FROM artist a
 WHERE
     (:filter_artists = FALSE OR a.uri IN :artist_uris)
     AND
-    (:filter_tracks = FALSE OR ta.track_uri IN :track_uris)
+    ta.track_uri IN (SELECT track_uri FROM matching_track_uris)
     AND
     (:filter_mbids = FALSE OR mba.artist_mbid IN :mbids)
     AND

--- a/data/sql/queries/select_genre_track_counts.sql
+++ b/data/sql/queries/select_genre_track_counts.sql
@@ -20,5 +20,5 @@ SELECT
 FROM artist_genre ag
     INNER JOIN track_artist ta ON ag.artist_uri = ta.artist_uri
     LEFT JOIN liked_track lt ON ta.track_uri = lt.track_uri
-WHERE ta.track_uri in %(track_uris)s
+WHERE ta.track_uri IN (SELECT track_uri FROM matching_track_uris)
 GROUP BY ag.genre;

--- a/data/sql/queries/select_label_track_counts.sql
+++ b/data/sql/queries/select_label_track_counts.sql
@@ -18,5 +18,5 @@ SELECT
 FROM record_label rl
     INNER JOIN track t ON t.album_uri = rl.album_uri
     LEFT JOIN liked_track lt ON lt.track_uri = t.uri
-WHERE t.uri IN %(track_uris)s
+WHERE t.uri IN (SELECT track_uri FROM matching_track_uris)
 GROUP BY rl.standardized_label;

--- a/data/sql/queries/select_playlists.sql
+++ b/data/sql/queries/select_playlists.sql
@@ -9,7 +9,7 @@ SELECT
         SELECT COUNT(pt.track_uri)
         FROM playlist_track pt
         WHERE playlist_uri = p.uri
-            AND (:filter_tracks = FALSE OR pt.track_uri IN :track_uris)
+            AND pt.track_uri IN (SELECT track_uri FROM matching_track_uris)
     ) AS playlist_track_count,
     (
         SELECT COUNT(track_uri)
@@ -21,7 +21,7 @@ SELECT
         FROM playlist_track pt
             INNER JOIN liked_track lt ON lt.track_uri = pt.track_uri
         WHERE playlist_uri = p.uri
-            AND (:filter_tracks = FALSE OR pt.track_uri IN :track_uris)
+            AND pt.track_uri IN (SELECT track_uri FROM matching_track_uris)
     ) AS playlist_liked_track_count,
     (
         SELECT COUNT(ipt.track_uri)
@@ -32,7 +32,7 @@ SELECT
 FROM playlist p
     INNER JOIN playlist_track pt ON pt.playlist_uri = p.uri
 WHERE
-    (:filter_tracks = FALSE OR pt.track_uri IN :track_uris)
+    pt.track_uri IN (SELECT track_uri FROM matching_track_uris)
 GROUP BY
     p.uri,
     p.name,

--- a/data/sql/queries/select_producers.sql
+++ b/data/sql/queries/select_producers.sql
@@ -12,7 +12,7 @@ FROM mb_recording_credit rc
     LEFT JOIN liked_track lt ON stmr.spotify_track_uri = lt.track_uri
     LEFT JOIN sp_artist_mb_artist sama ON sama.artist_mbid = mb.artist_mbid
     LEFT JOIN artist a ON sama.spotify_artist_uri = a.uri
-WHERE :filter_tracks = FALSE OR stmr.spotify_track_uri IN :track_uris
+WHERE stmr.spotify_track_uri IN (SELECT track_uri FROM matching_track_uris)
     AND rc.credit_type IN (
         'songwriter',
         'lyricist',

--- a/data/sql/queries/select_release_year_track_counts.sql
+++ b/data/sql/queries/select_release_year_track_counts.sql
@@ -53,6 +53,6 @@ FROM (
     FROM album ial
     INNER JOIN track it ON it.album_uri = ial.uri
     LEFT JOIN liked_track ilt ON ilt.track_uri = it.uri
-    WHERE it.uri IN %(track_uris)s
+    WHERE it.uri IN (SELECT track_uri FROM matching_track_uris)
 ) i
 GROUP BY i.album_release_year

--- a/data/sql/queries/select_track_recommendations_jump_back_in.sql
+++ b/data/sql/queries/select_track_recommendations_jump_back_in.sql
@@ -1,6 +1,6 @@
 -- Find liked tracks with significant listening history that haven't been played recently
 -- Uses percentile to find tracks with above-average play counts
--- Parameters: :percentile (0.0 to 1.0), :filter_tracks (boolean), :track_uris (array)
+-- Parameters: percentile (0.0 to 1.0), filter_tracks (boolean)
 WITH track_stats AS (
     SELECT 
         s.track_uri,

--- a/data/sql/queries/select_track_recommendations_jump_back_in.sql
+++ b/data/sql/queries/select_track_recommendations_jump_back_in.sql
@@ -8,7 +8,7 @@ WITH track_stats AS (
         MAX(s.played_at) AS last_played
     FROM track_stream s
     INNER JOIN liked_track lt ON lt.track_uri = s.track_uri
-    WHERE (:filter_tracks = FALSE OR s.track_uri IN :track_uris)
+    WHERE (:filter_tracks = FALSE OR s.track_uri IN (SELECT track_uri FROM matching_track_uris))
     GROUP BY s.track_uri
 ),
 stream_percentiles AS (

--- a/data/sql/queries/select_track_recommendations_still_interested.sql
+++ b/data/sql/queries/select_track_recommendations_still_interested.sql
@@ -9,7 +9,7 @@ WITH track_stats AS (
         MAX(s.played_at) AS last_played
     FROM track_stream s
     INNER JOIN liked_track lt ON lt.track_uri = s.track_uri
-    WHERE (:filter_tracks = FALSE OR s.track_uri IN :track_uris)
+    WHERE (:filter_tracks = FALSE OR s.track_uri IN (SELECT track_uri FROM matching_track_uris))
     GROUP BY s.track_uri
 ),
 stream_percentiles AS (

--- a/data/sql/queries/select_track_recommendations_still_interested.sql
+++ b/data/sql/queries/select_track_recommendations_still_interested.sql
@@ -1,6 +1,6 @@
 -- Find liked tracks in the bottom 60% by streams that haven't been played recently
 -- Uses percentile to find tracks with below-average play counts
--- Parameters: :percentile (0.0 to 1.0) - typically 0.6 for bottom 60%, :filter_tracks (boolean), :track_uris (array)
+-- Parameters: percentile (0.0 to 1.0) - typically 0.6 for bottom 60%, filter_tracks (boolean)
 -- Note: Using <= with percentile 0.6 returns tracks at or below the 60th percentile (the bottom 60%)
 WITH track_stats AS (
     SELECT 

--- a/routes/albums.py
+++ b/routes/albums.py
@@ -1,12 +1,22 @@
-import typing
+import pandas as pd
+import sqlalchemy
 
 from routes.utils import to_json
-from data.provider import DataProvider
+from data.filters import filtered_connection
+from data.query import query_text
 
 
-def albums_payload(track_uris: typing.Iterable[str], min_date, max_date):
-    if track_uris is None or len(track_uris) == 0:
+def albums_payload(filters: dict):
+    with filtered_connection(filters) as (conn, params):
+        # Create the album stream counts temp table within the same connection
+        albums = pd.read_sql_query(
+            sqlalchemy.text(query_text('select_albums')),
+            conn,
+            params={
+                "wrapped_start_date": params["wrapped_start_date"],
+                "wrapped_end_date": params["wrapped_end_date"],
+            }
+        )
+    if albums.empty:
         return {}
-    dp = DataProvider()
-    albums = dp.albums(track_uris=track_uris, start_date=min_date, end_date=max_date)
     return to_json(albums, 'album_uri')

--- a/routes/artists.py
+++ b/routes/artists.py
@@ -1,15 +1,28 @@
-import typing
+import pandas as pd
+import sqlalchemy
 
 from routes.utils import to_json
+from data.filters import filtered_connection
 from data.provider import DataProvider
+from data.query import query_text
 
 
-def artists_payload(track_uris: typing.Iterable[str], min_date, max_date):
-    if track_uris is None or len(track_uris) == 0:
+def artists_payload(filters: dict):
+    with filtered_connection(filters) as (conn, params):
+        artists = pd.read_sql_query(
+            sqlalchemy.text(query_text('select_artists')),
+            conn,
+            params={
+                "filter_artists": False,
+                "artist_uris": ('EMPTY',),
+                "filter_mbids": False,
+                "mbids": ('EMPTY',),
+                "wrapped_start_date": params["wrapped_start_date"],
+                "wrapped_end_date": params["wrapped_end_date"],
+            }
+        )
+    if artists.empty:
         return {}
-
-    dp = DataProvider()
-    artists = dp.artists(track_uris=track_uris, start_date=min_date, end_date=max_date)
     return to_json(artists, 'artist_uri')
 
 

--- a/routes/genres.py
+++ b/routes/genres.py
@@ -1,29 +1,28 @@
-import typing
+import pandas as pd
+import sqlalchemy
 
+from data.filters import filtered_connection
 from data.query import query_text
-from data.raw import get_connection
 
 
-def genres_payload(track_uris: typing.Iterable[str]):
-    if track_uris is None or len(track_uris) == 0:
-        return []
-    
-    with get_connection() as conn:
-        cursor = conn.cursor()
-        cursor.execute(
-            query_text('select_genre_track_counts'), 
-            { "track_uris": tuple(track_uris) }
+def genres_payload(filters: dict):
+    with filtered_connection(filters) as (conn, params):
+        genres = pd.read_sql_query(
+            sqlalchemy.text(query_text('select_genre_track_counts')),
+            conn
         )
-        result = cursor.fetchall()
+
+    if genres.empty:
+        return []
 
     out = []
-    for genre, track_count, total_track_count, liked_track_count, total_liked_track_count in result:
+    for _, row in genres.iterrows():
         out.append({
-            "genre": genre,
-            "track_count": track_count,
-            "liked_track_count": liked_track_count,
-            "total_track_count": total_track_count,
-            "total_liked_track_count": total_liked_track_count
+            "genre": row['genre'],
+            "track_count": int(row['genre_track_count']),
+            "total_track_count": int(row['genre_total_track_count']),
+            "liked_track_count": int(row['genre_liked_track_count']),
+            "total_liked_track_count": int(row['genre_total_liked_track_count']),
         })
 
     return out

--- a/routes/labels.py
+++ b/routes/labels.py
@@ -1,29 +1,28 @@
-import typing
+import pandas as pd
+import sqlalchemy
 
+from data.filters import filtered_connection
 from data.query import query_text
-from data.raw import get_connection
 
 
-def labels_payload(track_uris: typing.Iterable[str]):
-    if len(track_uris) == 0:
-        return []
-    
-    with get_connection() as conn:
-        cursor = conn.cursor()
-        cursor.execute(
-            query_text('select_label_track_counts'), 
-            { "track_uris": tuple(track_uris) }
+def labels_payload(filters: dict):
+    with filtered_connection(filters) as (conn, params):
+        labels = pd.read_sql_query(
+            sqlalchemy.text(query_text('select_label_track_counts')),
+            conn
         )
-        result = cursor.fetchall()
+
+    if labels.empty:
+        return []
 
     out = []
-    for label, track_count, total_track_count, liked_track_count, total_liked_track_count in result:
+    for _, row in labels.iterrows():
         out.append({
-            "label": label,
-            "track_count": track_count,
-            "total_track_count": total_track_count,
-            "liked_track_count": liked_track_count,
-            "total_liked_track_count": total_liked_track_count
+            "label": row['label'],
+            "track_count": int(row['label_track_count']),
+            "total_track_count": int(row['label_total_track_count']),
+            "liked_track_count": int(row['label_liked_track_count']),
+            "total_liked_track_count": int(row['label_total_liked_track_count']),
         })
 
     return out

--- a/routes/playlists.py
+++ b/routes/playlists.py
@@ -1,12 +1,17 @@
-import typing
+import pandas as pd
+import sqlalchemy
 
 from routes.utils import to_json
-from data.provider import DataProvider
+from data.filters import filtered_connection
+from data.query import query_text
 
 
-def playlists_payload(track_uris: typing.Iterable[str]):
-    if track_uris is None or len(track_uris) == 0:
+def playlists_payload(filters: dict):
+    with filtered_connection(filters) as (conn, params):
+        playlists = pd.read_sql_query(
+            sqlalchemy.text(query_text('select_playlists')),
+            conn
+        )
+    if playlists.empty:
         return {}
-    dp = DataProvider()
-    playlists = dp.playlists(track_uris=track_uris)
     return to_json(playlists, 'playlist_uri')

--- a/routes/producers.py
+++ b/routes/producers.py
@@ -1,7 +1,18 @@
-from routes.utils import to_json
-from data.provider import DataProvider
+import pandas as pd
+import sqlalchemy
 
-def producers_payload(track_uris=None):
-    dp = DataProvider()
-    producers = dp.producers(track_uris=track_uris)
+from routes.utils import to_json
+from data.filters import filtered_connection
+from data.query import query_text
+
+
+def producers_payload(filters: dict):
+    with filtered_connection(filters) as (conn, params):
+        producers = pd.read_sql_query(
+            sqlalchemy.text(query_text('select_producers')),
+            conn
+        )
+    if producers.empty:
+        return {}
+    producers.drop_duplicates(subset=['producer_mbid'], keep='first', inplace=True)
     return to_json(producers, 'producer_mbid')

--- a/routes/recommendations.py
+++ b/routes/recommendations.py
@@ -1,31 +1,47 @@
-import typing
 import pandas as pd
 import sqlalchemy
 
+from data.filters import filtered_connection, parse_filters
 from data.query import query_text
-from data.raw import get_engine
 
 
-def recommendations_payload(track_uris: typing.Optional[typing.List[str]] = None):
+def recommendations_payload(filters: dict):
     recommendations = {}
     
-    filter_tracks = track_uris is not None and len(track_uris) > 0
+    params = parse_filters(filters)
     
-    # Don't show recommendations if viewing fewer than 60 tracks
-    if filter_tracks and len(track_uris) < 60:
-        return recommendations
-    
-    # Use a tuple for SQL IN clause, with a dummy value if empty to avoid SQL errors
-    track_uris_tuple = tuple(track_uris) if filter_tracks else ('__none__',)
+    # Determine if any filters are active
+    has_filters = any([
+        params["filter_tracks"],
+        params["filter_playlists"],
+        params["filter_artists"],
+        params["filter_albums"],
+        params["filter_labels"],
+        params["filter_genres"],
+        params["filter_producers"],
+        params["filter_years"],
+        params["liked"],
+        params["wrapped_start_date"] is not None,
+    ])
 
-    with get_engine().begin() as conn:
+    with filtered_connection(filters) as (conn, filter_params):
+        if has_filters:
+            # Check track count to avoid showing recommendations for very small filter sets
+            track_count = pd.read_sql_query(
+                sqlalchemy.text("SELECT COUNT(*) AS cnt FROM matching_track_uris"),
+                conn
+            ).iloc[0]['cnt']
+            if track_count < 60:
+                return recommendations
+        
+        filter_tracks = has_filters
+
         still_interested_tracks = pd.read_sql_query(
             sqlalchemy.text(query_text('select_track_recommendations_still_interested')),
             conn,
             params={
                 'percentile': 0.6,
                 'filter_tracks': filter_tracks,
-                'track_uris': track_uris_tuple
             }
         )
         if not still_interested_tracks.empty and len(still_interested_tracks) >= 5:
@@ -40,7 +56,6 @@ def recommendations_payload(track_uris: typing.Optional[typing.List[str]] = None
             params={
                 'percentile': 0.6,
                 'filter_tracks': filter_tracks,
-                'track_uris': track_uris_tuple
             }
         )
         if not track_recs.empty and len(track_recs) >= 5:
@@ -55,7 +70,6 @@ def recommendations_payload(track_uris: typing.Optional[typing.List[str]] = None
             params={
                 'percentile': 0.9,
                 'filter_tracks': filter_tracks,
-                'track_uris': track_uris_tuple
             }
         )
         if not top_tracks.empty and len(top_tracks) >= 5:
@@ -70,7 +84,6 @@ def recommendations_payload(track_uris: typing.Optional[typing.List[str]] = None
             params={
                 'percentile': 0.85,
                 'filter_tracks': filter_tracks,
-                'track_uris': track_uris_tuple
             }
         )
         if not artist_recs.empty and len(artist_recs) >= 5:
@@ -85,7 +98,6 @@ def recommendations_payload(track_uris: typing.Optional[typing.List[str]] = None
             params={
                 'percentile': 0.8,
                 'filter_tracks': filter_tracks,
-                'track_uris': track_uris_tuple
             }
         )
         if not album_recs.empty and len(album_recs) >= 5:

--- a/routes/release_years.py
+++ b/routes/release_years.py
@@ -1,29 +1,28 @@
-import typing
+import pandas as pd
+import sqlalchemy
 
+from data.filters import filtered_connection
 from data.query import query_text
-from data.raw import get_connection
 
 
-def release_years_payload(track_uris: typing.Iterable[str]):
-    if len(track_uris) == 0:
-        return []
-    
-    with get_connection() as conn:
-        cursor = conn.cursor()
-        cursor.execute(
-            query_text('select_release_year_track_counts'), 
-            { "track_uris": tuple(track_uris) }
+def release_years_payload(filters: dict):
+    with filtered_connection(filters) as (conn, params):
+        years = pd.read_sql_query(
+            sqlalchemy.text(query_text('select_release_year_track_counts')),
+            conn
         )
-        result = cursor.fetchall()
+
+    if years.empty:
+        return []
 
     out = []
-    for release_year, track_count, liked_track_count, total_track_count, total_liked_track_count in result:
+    for _, row in years.iterrows():
         out.append({
-            "release_year": int(release_year),
-            "track_count": track_count,
-            "liked_track_count": liked_track_count,
-            "total_track_count": total_track_count,
-            "total_liked_track_count": total_liked_track_count
+            "release_year": int(row['release_year']),
+            "track_count": int(row['track_count']),
+            "liked_track_count": int(row['liked_track_count']),
+            "total_track_count": int(row['total_track_count']),
+            "total_liked_track_count": int(row['total_liked_track_count']),
         })
 
     return out

--- a/utils/ranking.py
+++ b/utils/ranking.py
@@ -2,8 +2,10 @@ import typing
 import pandas as pd
 import sqlalchemy
 
+from data.filters import filtered_connection
 from data.query import query_text
 from data.raw import get_connection, get_engine
+from routes.utils import to_json
 
 
 def track_ranks_over_time(track_uris: typing.Iterable[str], from_date, to_date):
@@ -61,17 +63,7 @@ def track_streams_by_month(track_uris, from_date, to_date):
         )
         results = cursor.fetchall()
 
-    out = {}
-    for track_uri, year, month, stream_count in results:
-        year = int(year)
-        month = int(month)
-        if track_uri not in out:
-            out[track_uri] = {}
-        if year not in out[track_uri]:
-            out[track_uri][year] = {}
-        if month not in out[track_uri][year]:
-            out[track_uri][year][month] = stream_count
-    return out
+    return _streams_by_month_dict(results, 0)
 
 
 def artist_streams_by_month(artist_uris, from_date, to_date):
@@ -88,17 +80,7 @@ def artist_streams_by_month(artist_uris, from_date, to_date):
         )
         results = cursor.fetchall()
 
-    out = {}
-    for artist_uri, year, month, stream_count in results:
-        year = int(year)
-        month = int(month)
-        if artist_uri not in out:
-            out[artist_uri] = {}
-        if year not in out[artist_uri]:
-            out[artist_uri][year] = {}
-        if month not in out[artist_uri][year]:
-            out[artist_uri][year][month] = stream_count
-    return out
+    return _streams_by_month_dict(results, 0)
 
 
 def album_streams_by_month(album_uris, from_date, to_date):
@@ -115,14 +97,121 @@ def album_streams_by_month(album_uris, from_date, to_date):
         )
         results = cursor.fetchall()
 
+    return _streams_by_month_dict(results, 0)
+
+
+# --- Filter-based variants (server-side top-N selection) ---
+
+def filtered_track_ranks_over_time(filters: dict, n: int = 10):
+    with filtered_connection(filters) as (conn, params):
+        return pd.read_sql_query(
+            sqlalchemy.text(query_text('filtered_track_ranks_over_time')),
+            conn,
+            params={
+                "from_date": params["wrapped_start_date"],
+                "to_date": params["wrapped_end_date"],
+                "n": n,
+            }
+        )
+
+
+def filtered_track_streams_by_month(filters: dict, n: int = 5):
+    with filtered_connection(filters) as (conn, params):
+        df = pd.read_sql_query(
+            sqlalchemy.text(query_text('filtered_track_streams_by_month')),
+            conn,
+            params={
+                "from_date": params["wrapped_start_date"],
+                "to_date": params["wrapped_end_date"],
+                "n": n,
+            }
+        )
+    return _streams_by_month_dict_from_df(df)
+
+
+def filtered_artist_ranks_over_time(filters: dict, n: int = 10):
+    with filtered_connection(filters) as (conn, params):
+        return pd.read_sql_query(
+            sqlalchemy.text(query_text('filtered_artist_ranks_over_time')),
+            conn,
+            params={
+                "from_date": params["wrapped_start_date"],
+                "to_date": params["wrapped_end_date"],
+                "n": n,
+            }
+        )
+
+
+def filtered_artist_streams_by_month(filters: dict, n: int = 5):
+    with filtered_connection(filters) as (conn, params):
+        df = pd.read_sql_query(
+            sqlalchemy.text(query_text('filtered_artist_streams_by_month')),
+            conn,
+            params={
+                "from_date": params["wrapped_start_date"],
+                "to_date": params["wrapped_end_date"],
+                "n": n,
+            }
+        )
+    return _streams_by_month_dict_from_df(df)
+
+
+def filtered_album_ranks_over_time(filters: dict, n: int = 10):
+    with filtered_connection(filters) as (conn, params):
+        return pd.read_sql_query(
+            sqlalchemy.text(query_text('filtered_album_ranks_over_time')),
+            conn,
+            params={
+                "from_date": params["wrapped_start_date"],
+                "to_date": params["wrapped_end_date"],
+                "n": n,
+            }
+        )
+
+
+def filtered_album_streams_by_month(filters: dict, n: int = 5):
+    with filtered_connection(filters) as (conn, params):
+        df = pd.read_sql_query(
+            sqlalchemy.text(query_text('filtered_album_streams_by_month')),
+            conn,
+            params={
+                "from_date": params["wrapped_start_date"],
+                "to_date": params["wrapped_end_date"],
+                "n": n,
+            }
+        )
+    return _streams_by_month_dict_from_df(df)
+
+
+def _streams_by_month_dict(results, uri_index):
+    """Convert raw cursor results (uri, year, month, count) to nested dict."""
     out = {}
-    for album_uri, year, month, stream_count in results:
-        year = int(year)
-        month = int(month)
-        if album_uri not in out:
-            out[album_uri] = {}
-        if year not in out[album_uri]:
-            out[album_uri][year] = {}
-        if month not in out[album_uri][year]:
-            out[album_uri][year][month] = stream_count
+    for row in results:
+        uri = row[uri_index]
+        year = int(row[1])
+        month = int(row[2])
+        stream_count = row[3]
+        if uri not in out:
+            out[uri] = {}
+        if year not in out[uri]:
+            out[uri][year] = {}
+        if month not in out[uri][year]:
+            out[uri][year][month] = stream_count
+    return out
+
+
+def _streams_by_month_dict_from_df(df):
+    """Convert a DataFrame with columns (uri, year, month, stream_count) to nested dict."""
+    out = {}
+    for _, row in df.iterrows():
+        uri = row.iloc[0]
+        year = int(row.iloc[1])
+        month = int(row.iloc[2])
+        stream_count = int(row.iloc[3])
+        if uri not in out:
+            out[uri] = {}
+        if year not in out[uri]:
+            out[uri][year] = {}
+        if month not in out[uri][year]:
+            out[uri][year][month] = stream_count
     return out


### PR DESCRIPTION
## Summary

All endpoints that previously required a pre-computed list of track URIs now accept the full filter set (playlists, artists, albums, labels, genres, producers, years, liked, wrapped) directly.

This is the backend foundation for eliminating the client-side track-ID-list waterfall pattern, where:
1. Client calls `/api/tracks/search` → gets all matching track URIs
2. Client sends those URIs to every other endpoint

With this change, each endpoint can independently resolve which tracks match the filters, enabling parallel requests.

## Key changes

- **New `data/filters.py`**: shared filter parsing and `matching_track_uris` temp table infrastructure
- **New `create_matching_track_uris.sql`**: reusable temp table encapsulating all filter logic from `select_tracks.sql`
- **Updated 12 SQL queries** to reference the temp table instead of `IN :track_uris` params
- **Updated all route handlers** to accept filter dicts and use `filtered_connection()` context manager
- **Updated `DataProvider` methods** to create matching temp table within their own connections

## Backward compatibility

Sending `{tracks: [...]}` in the request body still works — `parse_filters` treats it as `filter_tracks=True` and the temp table contains exactly those tracks. The frontend can be updated independently in a follow-up PR.

## Part of a series

This is PR 1 of 3:
1. **This PR** — Backend: all endpoints accept user-facing filters
2. Backend: streaming history/month endpoints accept filters + server-side top-N
3. Frontend: remove waterfall, all sections request in parallel