### PR TITLE
Streaming endpoints accept filters with server-side top-N selection

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -14,6 +14,7 @@ from routes.utils import to_date_range, to_json
 from routes.producers import producers_payload
 from data.sql.migrations.migrations import perform_all_migrations
 from utils.ranking import album_ranks_over_time, album_streams_by_month, artist_ranks_over_time, artist_streams_by_month, track_ranks_over_time, track_streams_by_month
+from utils.ranking import filtered_track_ranks_over_time, filtered_track_streams_by_month, filtered_artist_ranks_over_time, filtered_artist_streams_by_month, filtered_album_ranks_over_time, filtered_album_streams_by_month
 
 pd.options.mode.chained_assignment = None  # default='warn'
 app = Flask(__name__)
@@ -90,56 +91,74 @@ def list_release_years():
 
 @app.route("/api/streams/tracks/history", methods = ['POST'])
 def list_track_stream_history():
+    n = request.json.get('n', 10)
     track_uris = request.json.get('tracks', None)
-    if track_uris is None or len(track_uris) == 0:
-        return []
-    min_date, max_date = to_date_range(request.json.get('wrapped', None))
-    return to_json(track_ranks_over_time(track_uris, min_date, max_date))
+    if track_uris is not None:
+        if len(track_uris) == 0:
+            return []
+        min_date, max_date = to_date_range(request.json.get('wrapped', None))
+        return to_json(track_ranks_over_time(track_uris, min_date, max_date))
+    return to_json(filtered_track_ranks_over_time(request.json, n))
 
 
 @app.route("/api/streams/tracks/months", methods = ['POST'])
 def list_track_streams_by_month():
+    n = request.json.get('n', 5)
     track_uris = request.json.get('tracks', None)
-    if track_uris is None or len(track_uris) == 0:
-        return {}
-    min_date, max_date = to_date_range(request.json.get('wrapped', None))
-    return track_streams_by_month(track_uris, min_date, max_date)
+    if track_uris is not None:
+        if len(track_uris) == 0:
+            return {}
+        min_date, max_date = to_date_range(request.json.get('wrapped', None))
+        return track_streams_by_month(track_uris, min_date, max_date)
+    return filtered_track_streams_by_month(request.json, n)
 
 
 @app.route("/api/streams/artists/history", methods = ['POST'])
 def list_artist_stream_history():
+    n = request.json.get('n', 10)
     artist_uris = request.json.get('artists', None)
-    if artist_uris is None or len(artist_uris) == 0:
-        return []
-    min_date, max_date = to_date_range(request.json.get('wrapped', None))
-    return to_json(artist_ranks_over_time(artist_uris, min_date, max_date))
+    if artist_uris is not None:
+        if len(artist_uris) == 0:
+            return []
+        min_date, max_date = to_date_range(request.json.get('wrapped', None))
+        return to_json(artist_ranks_over_time(artist_uris, min_date, max_date))
+    return to_json(filtered_artist_ranks_over_time(request.json, n))
 
 
 @app.route("/api/streams/artists/months", methods = ['POST'])
 def list_artist_streams_by_month():
+    n = request.json.get('n', 5)
     artist_uris = request.json.get('artists', None)
-    if artist_uris is None or len(artist_uris) == 0:
-        return {}
-    min_date, max_date = to_date_range(request.json.get('wrapped', None))
-    return artist_streams_by_month(artist_uris, min_date, max_date)
+    if artist_uris is not None:
+        if len(artist_uris) == 0:
+            return {}
+        min_date, max_date = to_date_range(request.json.get('wrapped', None))
+        return artist_streams_by_month(artist_uris, min_date, max_date)
+    return filtered_artist_streams_by_month(request.json, n)
 
 
 @app.route("/api/streams/albums/history", methods = ['POST'])
 def list_album_stream_history():
+    n = request.json.get('n', 10)
     album_uris = request.json.get('albums', None)
-    if album_uris is None or len(album_uris) == 0:
-        return []
-    min_date, max_date = to_date_range(request.json.get('wrapped', None))
-    return to_json(album_ranks_over_time(album_uris, min_date, max_date))
+    if album_uris is not None:
+        if len(album_uris) == 0:
+            return []
+        min_date, max_date = to_date_range(request.json.get('wrapped', None))
+        return to_json(album_ranks_over_time(album_uris, min_date, max_date))
+    return to_json(filtered_album_ranks_over_time(request.json, n))
 
 
 @app.route("/api/streams/albums/months", methods = ['POST'])
 def list_album_streams_by_month():
+    n = request.json.get('n', 5)
     album_uris = request.json.get('albums', None)
-    if album_uris is None or len(album_uris) == 0:
-        return {}
-    min_date, max_date = to_date_range(request.json.get('wrapped', None))
-    return album_streams_by_month(album_uris, min_date, max_date)
+    if album_uris is not None:
+        if len(album_uris) == 0:
+            return {}
+        min_date, max_date = to_date_range(request.json.get('wrapped', None))
+        return album_streams_by_month(album_uris, min_date, max_date)
+    return filtered_album_streams_by_month(request.json, n)
 
 
 @app.route("/api/recommendations", methods = ['POST'])

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -237,49 +237,49 @@ export async function getTrackCredits(uri: string): Promise<Credit[]> {
 }
 
 export async function getPlaylists(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Record<string, Playlist>> {
   return sendRequest(`/api/playlists`, "playlists", filters);
 }
 
 export async function getArtists(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Record<string, Artist>> {
   return sendRequest(`/api/artists`, "artists", filters);
 }
 
 export async function getAlbums(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Record<string, Album>> {
   return sendRequest(`/api/albums`, "albums", filters);
 }
 
 export async function getLabels(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Label[]> {
   return sendRequest(`/api/labels`, "labels", filters);
 }
 
 export async function getGenres(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Genre[]> {
   return sendRequest(`/api/genres`, "genres", filters);
 }
 
 export async function getProducers(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Record<string, Producer>> {
   return sendRequest(`/api/producers`, "producers", filters);
 }
 
 export async function getReleaseYears(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<ReleaseYear[]> {
   return sendRequest(`/api/release-years`, "release years", filters);
 }
 
 export async function getTracksStreamingHistory(
-  filters: Pick<ActiveFilters, "tracks" | "wrapped">
+  filters: ActiveFilters & { n?: number }
 ): Promise<TrackRank[]> {
   return sendRequest(
     `/api/streams/tracks/history`,
@@ -289,7 +289,7 @@ export async function getTracksStreamingHistory(
 }
 
 export async function getArtistsStreamingHistory(
-  filters: Pick<ActiveFilters, "artists" | "wrapped">
+  filters: ActiveFilters & { n?: number }
 ): Promise<ArtistRank[]> {
   return sendRequest(
     `/api/streams/artists/history`,
@@ -299,7 +299,7 @@ export async function getArtistsStreamingHistory(
 }
 
 export async function getAlbumsStreamingHistory(
-  filters: Pick<ActiveFilters, "albums" | "wrapped">
+  filters: ActiveFilters & { n?: number }
 ): Promise<AlbumRank[]> {
   return sendRequest(
     `/api/streams/albums/history`,
@@ -309,7 +309,7 @@ export async function getAlbumsStreamingHistory(
 }
 
 export async function getTracksStreamsByMonth(
-  filters: Pick<ActiveFilters, "tracks" | "wrapped">
+  filters: ActiveFilters & { n?: number }
 ): Promise<StreamsByMonth> {
   return sendRequest(
     `/api/streams/tracks/months`,
@@ -319,7 +319,7 @@ export async function getTracksStreamsByMonth(
 }
 
 export async function getArtistsStreamsByMonth(
-  filters: Pick<ActiveFilters, "artists" | "wrapped">
+  filters: ActiveFilters & { n?: number }
 ): Promise<StreamsByMonth> {
   return sendRequest(
     `/api/streams/artists/months`,
@@ -329,7 +329,7 @@ export async function getArtistsStreamsByMonth(
 }
 
 export async function getAlbumsStreamsByMonth(
-  filters: Pick<ActiveFilters, "albums" | "wrapped">
+  filters: ActiveFilters & { n?: number }
 ): Promise<StreamsByMonth> {
   return sendRequest(
     `/api/streams/albums/months`,
@@ -346,7 +346,7 @@ export interface RecommendationList {
 export type Recommendations = Record<string, RecommendationList>;
 
 export async function getRecommendations(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Recommendations> {
   return sendRequest(`/api/recommendations`, "recommendations", filters);
 }

--- a/client/src/charts/TracksStreamingHistoryStack.tsx
+++ b/client/src/charts/TracksStreamingHistoryStack.tsx
@@ -3,16 +3,16 @@ import { useState } from "react";
 import { Track } from "../api";
 import { ChartSkeleton } from "../design/ChartSkeleton";
 import { mostStreamedTracks } from "../sorting";
-import { useTracksCount, useTracksStreamsByMonth } from "../useApi";
+import { useTracksCount, useTracksStreamsByMonth, useTracks } from "../useApi";
 import styles from "./StreamingHistoryItem.module.css";
 import { StreamingHistoryStack } from "./StreamingHistoryStack";
 
 export function TracksStreamingHistoryStack() {
   const [n, setN] = useState(5);
   const { data: trackCount } = useTracksCount();
+  const { data: tracks } = useTracks();
   const {
     data: streamsByMonth,
-    tracks,
     shouldRender,
   } = useTracksStreamsByMonth(n);
 

--- a/client/src/useApi.ts
+++ b/client/src/useApi.ts
@@ -2,11 +2,17 @@ import { useQuery } from "@tanstack/react-query";
 
 import {
   ActiveFilters,
+  Album,
   AlbumRank,
+  Artist,
   ArtistCreditsData,
   ArtistRank,
   Credit,
   FilterOptions,
+  Genre,
+  Label,
+  Playlist,
+  Producer,
   getAlbums,
   getAlbumsStreamingHistory,
   getAlbumsStreamsByMonth,
@@ -26,17 +32,14 @@ import {
   getTracksStreamingHistory,
   getTracksStreamsByMonth,
   Recommendations,
+  ReleaseYear,
   searchTracks,
+  StreamsByMonth,
   toFiltersQuery,
   Track,
   TrackDetails,
   TrackRank,
 } from "./api";
-import {
-  mostStreamedAlbums,
-  mostStreamedArtists,
-  mostStreamedTracks,
-} from "./sorting";
 import { useFilters } from "./useFilters";
 import { countUniqueAsOfDates, countUniqueMonths } from "./utils";
 
@@ -96,11 +99,25 @@ export function useTrackCredits(uri: string) {
 }
 
 export function usePlaylists(filters?: ActiveFilters) {
-  return useTracksDependentQuery("playlists", getPlaylists, {}, filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<Record<string, Playlist>>({
+    ...defaultQueryOptions,
+    queryKey: ["playlists", query],
+    queryFn: async () => getPlaylists(activeFilters),
+  });
 }
 
 export function useArtists(filters?: ActiveFilters) {
-  return useTracksDependentQuery("artists", getArtists, {}, filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<Record<string, Artist>>({
+    ...defaultQueryOptions,
+    queryKey: ["artists", query],
+    queryFn: async () => getArtists(activeFilters),
+  });
 }
 
 export function useArtistCredits(artistUri: string) {
@@ -112,41 +129,67 @@ export function useArtistCredits(artistUri: string) {
 }
 
 export function useAlbums(filters?: ActiveFilters) {
-  return useTracksDependentQuery("albums", getAlbums, {}, filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<Record<string, Album>>({
+    ...defaultQueryOptions,
+    queryKey: ["albums", query],
+    queryFn: async () => getAlbums(activeFilters),
+  });
 }
 
 export function useLabels(filters?: ActiveFilters) {
-  return useTracksDependentQuery("labels", getLabels, [], filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<Label[]>({
+    ...defaultQueryOptions,
+    queryKey: ["labels", query],
+    queryFn: async () => getLabels(activeFilters),
+  });
 }
 
 export function useGenres(filters?: ActiveFilters) {
-  return useTracksDependentQuery("genres", getGenres, [], filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<Genre[]>({
+    ...defaultQueryOptions,
+    queryKey: ["genres", query],
+    queryFn: async () => getGenres(activeFilters),
+  });
 }
 
 export function useReleaseYears(filters?: ActiveFilters) {
-  return useTracksDependentQuery("release-years", getReleaseYears, [], filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<ReleaseYear[]>({
+    ...defaultQueryOptions,
+    queryKey: ["release-years", query],
+    queryFn: async () => getReleaseYears(activeFilters),
+  });
 }
 
 export function useProducers(filters?: ActiveFilters) {
-  return useTracksDependentQuery("producers", getProducers, {}, filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<Record<string, Producer>>({
+    ...defaultQueryOptions,
+    queryKey: ["producers", query],
+    queryFn: async () => getProducers(activeFilters),
+  });
 }
 
 export function useTracksStreamingHistory() {
   const filters = useFilters();
-  const { data: tracks } = useTracks();
-
-  const topTenUris = Object.values(tracks ?? {})
-    .sort(mostStreamedTracks)
-    .slice(0, 10)
-    .map((t) => t.track_uri);
-
-  const tracksFilter = { tracks: topTenUris, wrapped: filters.wrapped };
-  const query = toFiltersQuery(tracksFilter);
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
   const result = useQuery<TrackRank[]>({
     ...defaultQueryOptions,
     queryKey: ["tracks-streaming-history", query],
-    enabled: !!tracks,
-    queryFn: async () => getTracksStreamingHistory(tracksFilter),
+    queryFn: async () => getTracksStreamingHistory({ ...filters, n: 10 }),
   });
 
   const shouldRender = !result.data || countUniqueAsOfDates(result.data) > 4;
@@ -156,20 +199,11 @@ export function useTracksStreamingHistory() {
 
 export function useArtistsStreamingHistory() {
   const filters = useFilters();
-  const { data: artists } = useArtists();
-
-  const topTenUris = Object.values(artists ?? {})
-    .sort(mostStreamedArtists)
-    .slice(0, 10)
-    .map((t) => t.artist_uri);
-
-  const artistsFilter = { artists: topTenUris, wrapped: filters.wrapped };
-  const query = toFiltersQuery(artistsFilter);
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
   const result = useQuery<ArtistRank[]>({
     ...defaultQueryOptions,
     queryKey: ["artists-streaming-history", query],
-    enabled: !!artists,
-    queryFn: async () => getArtistsStreamingHistory(artistsFilter),
+    queryFn: async () => getArtistsStreamingHistory({ ...filters, n: 10 }),
   });
 
   const shouldRender = !result.data || countUniqueAsOfDates(result.data) > 4;
@@ -179,20 +213,11 @@ export function useArtistsStreamingHistory() {
 
 export function useAlbumsStreamingHistory() {
   const filters = useFilters();
-  const { data: albums } = useAlbums();
-
-  const topTenUris = Object.values(albums ?? {})
-    .sort(mostStreamedAlbums)
-    .slice(0, 10)
-    .map((t) => t.album_uri);
-
-  const albumsFilter = { albums: topTenUris, wrapped: filters.wrapped };
-  const query = toFiltersQuery(albumsFilter);
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
   const result = useQuery<AlbumRank[]>({
     ...defaultQueryOptions,
     queryKey: ["albums-streaming-history", query],
-    enabled: !!albums,
-    queryFn: async () => getAlbumsStreamingHistory(albumsFilter),
+    queryFn: async () => getAlbumsStreamingHistory({ ...filters, n: 10 }),
   });
 
   const shouldRender = !result.data || countUniqueAsOfDates(result.data) > 4;
@@ -201,22 +226,13 @@ export function useAlbumsStreamingHistory() {
 }
 
 export function useTracksStreamsByMonth(n: number = 5) {
-  function getTopNTracksStreamsByMonth(
-    filters: ActiveFilters,
-    tracks: Record<string, Track>
-  ) {
-    const topNUris = Object.values(tracks ?? {})
-      .sort(mostStreamedTracks)
-      .slice(0, n)
-      .map((t) => t.track_uri);
-    return getTracksStreamsByMonth({ ...filters, tracks: topNUris });
-  }
-
-  const result = useTracksDependentQuery(
-    "tracks-streams-by-month-" + n,
-    getTopNTracksStreamsByMonth,
-    {}
-  );
+  const filters = useFilters();
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
+  const result = useQuery<StreamsByMonth>({
+    ...defaultQueryOptions,
+    queryKey: ["tracks-streams-by-month", query, n],
+    queryFn: async () => getTracksStreamsByMonth({ ...filters, n }),
+  });
 
   const shouldRender = !result.data || countUniqueMonths(result.data) > 3;
 
@@ -225,22 +241,11 @@ export function useTracksStreamsByMonth(n: number = 5) {
 
 export function useArtistsStreamsByMonth(n: number = 5) {
   const filters = useFilters();
-  const { data: artists } = useArtists();
-
-  const topNUris = Object.values(artists ?? {})
-    .sort(mostStreamedArtists)
-    .slice(0, n)
-    .map((t) => t.artist_uri);
-
-  const artistsFilter = { artists: topNUris, wrapped: filters.wrapped };
-  const query = toFiltersQuery(artistsFilter);
-  const result = useQuery<
-    Record<string, Record<number, Record<number, number>>>
-  >({
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
+  const result = useQuery<StreamsByMonth>({
     ...defaultQueryOptions,
     queryKey: ["artists-streams-by-month", query, n],
-    enabled: !!artists,
-    queryFn: async () => getArtistsStreamsByMonth(artistsFilter),
+    queryFn: async () => getArtistsStreamsByMonth({ ...filters, n }),
   });
 
   const shouldRender = !result.data || countUniqueMonths(result.data) > 3;
@@ -250,22 +255,11 @@ export function useArtistsStreamsByMonth(n: number = 5) {
 
 export function useAlbumsStreamsByMonth(n: number = 5) {
   const filters = useFilters();
-  const { data: albums } = useAlbums();
-
-  const topNUris = Object.values(albums ?? {})
-    .sort(mostStreamedAlbums)
-    .slice(0, n)
-    .map((t) => t.album_uri);
-
-  const albumsFilter = { albums: topNUris, wrapped: filters.wrapped };
-  const query = toFiltersQuery(albumsFilter);
-  const result = useQuery<
-    Record<string, Record<number, Record<number, number>>>
-  >({
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
+  const result = useQuery<StreamsByMonth>({
     ...defaultQueryOptions,
     queryKey: ["albums-streams-by-month", query, n],
-    enabled: !!albums,
-    queryFn: async () => getAlbumsStreamsByMonth(albumsFilter),
+    queryFn: async () => getAlbumsStreamsByMonth({ ...filters, n }),
   });
 
   const shouldRender = !result.data || countUniqueMonths(result.data) > 3;
@@ -275,63 +269,12 @@ export function useAlbumsStreamsByMonth(n: number = 5) {
 
 export function useRecommendations() {
   const filters = useFilters();
-  const query = toFiltersQuery({ wrapped: filters.wrapped, ...filters }) || DEFAULT_QUERY_KEY;
-
-  const { data: tracks, isSuccess } = useTracks(filters);
-  
-  // When no filters are applied, don't pass track URIs to avoid performance issues
-  // The server will handle unfiltered queries more efficiently without URIs
-  const hasFilters = Object.keys(filters).length > 0;
-  const tracksFilter = {
-    tracks: hasFilters ? (tracks ? Object.keys(tracks) : []) : undefined,
-    wrapped: filters.wrapped,
-  };
-
-  const result = useQuery<Recommendations>({
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
+  return useQuery<Recommendations>({
     ...defaultQueryOptions,
-    enabled: isSuccess,
     queryKey: ["recommendations", query],
-    queryFn: async () =>
-      hasFilters && tracksFilter.tracks && tracksFilter.tracks.length === 0
-        ? {}
-        : getRecommendations(tracksFilter),
+    queryFn: async () => getRecommendations(filters),
   });
-
-  return { ...result, tracks };
-}
-
-function useTracksDependentQuery<T>(
-  key: string,
-  getValue: (
-    filters: ActiveFilters,
-    tracks: Record<string, Track>
-  ) => Promise<T>,
-  defaultValue: T,
-  filters?: ActiveFilters
-) {
-  const globalFilters = useFilters();
-  filters ??= globalFilters;
-  const query =
-    toFiltersQuery({ wrapped: filters.wrapped, ...filters }) ||
-    DEFAULT_QUERY_KEY;
-
-  const { data: tracks, isSuccess } = useTracks(filters);
-  const tracksFilter = {
-    tracks: tracks ? Object.keys(tracks) : [],
-    wrapped: filters.wrapped,
-  };
-
-  const result = useQuery<T>({
-    ...defaultQueryOptions,
-    enabled: isSuccess,
-    queryKey: [key, query],
-    queryFn: async () =>
-      tracksFilter.tracks.length === 0
-        ? defaultValue
-        : getValue(tracksFilter, tracks!),
-  });
-
-  return { ...result, tracks };
 }
 
 // If a piece of a query key is an empty string, the request will not fire

--- a/data/sql/queries/filtered_album_ranks_over_time.sql
+++ b/data/sql/queries/filtered_album_ranks_over_time.sql
@@ -1,0 +1,38 @@
+WITH top_albums AS (
+    SELECT t.album_uri, COUNT(*) AS total_streams
+    FROM track_stream s
+    INNER JOIN track t ON t.uri = s.track_uri
+    WHERE s.track_uri IN (SELECT track_uri FROM matching_track_uris)
+        AND (:from_date IS NULL OR s.played_at >= :from_date)
+        AND (:to_date IS NULL OR s.played_at <= :to_date)
+    GROUP BY t.album_uri
+    ORDER BY total_streams DESC
+    LIMIT :n
+),
+month_ends AS (
+    SELECT DISTINCT DATE_TRUNC('month', s.played_at) + INTERVAL '1 month' - INTERVAL '1 second' AS as_of_date
+    FROM track_stream s
+    INNER JOIN track t ON t.uri = s.track_uri
+    WHERE t.album_uri IN (SELECT album_uri FROM top_albums)
+        AND (:from_date IS NULL OR s.played_at >= :from_date)
+        AND (:to_date IS NULL OR s.played_at <= :to_date)
+),
+cumulative_counts AS (
+    SELECT 
+        t.album_uri,
+        m.as_of_date,
+        COUNT(*) AS album_stream_count
+    FROM track_stream s
+    INNER JOIN track t ON t.uri = s.track_uri
+    CROSS JOIN month_ends m
+    WHERE t.album_uri IN (SELECT album_uri FROM top_albums)
+        AND s.played_at <= m.as_of_date
+    GROUP BY t.album_uri, m.as_of_date
+)
+SELECT 
+    album_uri,
+    0 AS album_rank,
+    album_stream_count,
+    as_of_date
+FROM cumulative_counts
+ORDER BY album_uri, as_of_date;

--- a/data/sql/queries/filtered_album_streams_by_month.sql
+++ b/data/sql/queries/filtered_album_streams_by_month.sql
@@ -1,0 +1,22 @@
+WITH top_albums AS (
+    SELECT t.album_uri, COUNT(*) AS total_streams
+    FROM track_stream s
+    INNER JOIN track t ON t.uri = s.track_uri
+    WHERE s.track_uri IN (SELECT track_uri FROM matching_track_uris)
+        AND (:from_date IS NULL OR s.played_at >= :from_date)
+        AND (:to_date IS NULL OR s.played_at <= :to_date)
+    GROUP BY t.album_uri
+    ORDER BY total_streams DESC
+    LIMIT :n
+)
+SELECT 
+    t.album_uri,
+    EXTRACT(YEAR FROM s.played_at)::INTEGER AS year,
+    EXTRACT(MONTH FROM s.played_at)::INTEGER AS month,
+    COUNT(*) AS stream_count
+FROM track_stream s
+INNER JOIN track t ON t.uri = s.track_uri
+WHERE t.album_uri IN (SELECT album_uri FROM top_albums)
+    AND (:from_date IS NULL OR s.played_at >= :from_date)
+    AND (:to_date IS NULL OR s.played_at <= :to_date)
+GROUP BY t.album_uri, year, month;

--- a/data/sql/queries/filtered_artist_ranks_over_time.sql
+++ b/data/sql/queries/filtered_artist_ranks_over_time.sql
@@ -1,0 +1,38 @@
+WITH top_artists AS (
+    SELECT ta.artist_uri, COUNT(*) AS total_streams
+    FROM track_stream s
+    INNER JOIN track_artist ta ON ta.track_uri = s.track_uri
+    WHERE s.track_uri IN (SELECT track_uri FROM matching_track_uris)
+        AND (:from_date IS NULL OR s.played_at >= :from_date)
+        AND (:to_date IS NULL OR s.played_at <= :to_date)
+    GROUP BY ta.artist_uri
+    ORDER BY total_streams DESC
+    LIMIT :n
+),
+month_ends AS (
+    SELECT DISTINCT DATE_TRUNC('month', s.played_at) + INTERVAL '1 month' - INTERVAL '1 second' AS as_of_date
+    FROM track_stream s
+    INNER JOIN track_artist ta ON ta.track_uri = s.track_uri
+    WHERE ta.artist_uri IN (SELECT artist_uri FROM top_artists)
+        AND (:from_date IS NULL OR s.played_at >= :from_date)
+        AND (:to_date IS NULL OR s.played_at <= :to_date)
+),
+cumulative_counts AS (
+    SELECT 
+        ta.artist_uri,
+        m.as_of_date,
+        COUNT(*) AS artist_stream_count
+    FROM track_stream s
+    INNER JOIN track_artist ta ON ta.track_uri = s.track_uri
+    CROSS JOIN month_ends m
+    WHERE ta.artist_uri IN (SELECT artist_uri FROM top_artists)
+        AND s.played_at <= m.as_of_date
+    GROUP BY ta.artist_uri, m.as_of_date
+)
+SELECT 
+    artist_uri,
+    0 AS artist_rank,
+    artist_stream_count,
+    as_of_date
+FROM cumulative_counts
+ORDER BY artist_uri, as_of_date;

--- a/data/sql/queries/filtered_artist_streams_by_month.sql
+++ b/data/sql/queries/filtered_artist_streams_by_month.sql
@@ -1,0 +1,22 @@
+WITH top_artists AS (
+    SELECT ta.artist_uri, COUNT(*) AS total_streams
+    FROM track_stream s
+    INNER JOIN track_artist ta ON ta.track_uri = s.track_uri
+    WHERE s.track_uri IN (SELECT track_uri FROM matching_track_uris)
+        AND (:from_date IS NULL OR s.played_at >= :from_date)
+        AND (:to_date IS NULL OR s.played_at <= :to_date)
+    GROUP BY ta.artist_uri
+    ORDER BY total_streams DESC
+    LIMIT :n
+)
+SELECT 
+    ta.artist_uri,
+    EXTRACT(YEAR FROM s.played_at)::INTEGER AS year,
+    EXTRACT(MONTH FROM s.played_at)::INTEGER AS month,
+    COUNT(*) AS stream_count
+FROM track_stream s
+INNER JOIN track_artist ta ON ta.track_uri = s.track_uri
+WHERE ta.artist_uri IN (SELECT artist_uri FROM top_artists)
+    AND (:from_date IS NULL OR s.played_at >= :from_date)
+    AND (:to_date IS NULL OR s.played_at <= :to_date)
+GROUP BY ta.artist_uri, year, month;

--- a/data/sql/queries/filtered_track_ranks_over_time.sql
+++ b/data/sql/queries/filtered_track_ranks_over_time.sql
@@ -1,0 +1,35 @@
+WITH top_tracks AS (
+    SELECT s.track_uri, COUNT(*) AS total_streams
+    FROM track_stream s
+    WHERE s.track_uri IN (SELECT track_uri FROM matching_track_uris)
+        AND (:from_date IS NULL OR s.played_at >= :from_date)
+        AND (:to_date IS NULL OR s.played_at <= :to_date)
+    GROUP BY s.track_uri
+    ORDER BY total_streams DESC
+    LIMIT :n
+),
+month_ends AS (
+    SELECT DISTINCT DATE_TRUNC('month', played_at) + INTERVAL '1 month' - INTERVAL '1 second' AS as_of_date
+    FROM track_stream
+    WHERE track_uri IN (SELECT track_uri FROM top_tracks)
+        AND (:from_date IS NULL OR played_at >= :from_date)
+        AND (:to_date IS NULL OR played_at <= :to_date)
+),
+cumulative_counts AS (
+    SELECT 
+        s.track_uri,
+        m.as_of_date,
+        COUNT(*) AS track_stream_count
+    FROM track_stream s
+    CROSS JOIN month_ends m
+    WHERE s.track_uri IN (SELECT track_uri FROM top_tracks)
+        AND s.played_at <= m.as_of_date
+    GROUP BY s.track_uri, m.as_of_date
+)
+SELECT 
+    track_uri,
+    0 AS track_rank,
+    track_stream_count,
+    as_of_date
+FROM cumulative_counts
+ORDER BY track_uri, as_of_date;

--- a/data/sql/queries/filtered_track_streams_by_month.sql
+++ b/data/sql/queries/filtered_track_streams_by_month.sql
@@ -1,0 +1,20 @@
+WITH top_tracks AS (
+    SELECT s.track_uri, COUNT(*) AS total_streams
+    FROM track_stream s
+    WHERE s.track_uri IN (SELECT track_uri FROM matching_track_uris)
+        AND (:from_date IS NULL OR s.played_at >= :from_date)
+        AND (:to_date IS NULL OR s.played_at <= :to_date)
+    GROUP BY s.track_uri
+    ORDER BY total_streams DESC
+    LIMIT :n
+)
+SELECT 
+    s.track_uri,
+    EXTRACT(YEAR FROM s.played_at)::INTEGER AS year,
+    EXTRACT(MONTH FROM s.played_at)::INTEGER AS month,
+    COUNT(*) AS stream_count
+FROM track_stream s
+WHERE s.track_uri IN (SELECT track_uri FROM top_tracks)
+    AND (:from_date IS NULL OR s.played_at >= :from_date)
+    AND (:to_date IS NULL OR s.played_at <= :to_date)
+GROUP BY s.track_uri, year, month;

--- a/data/sql/queries/select_album_recommendations_rediscover.sql
+++ b/data/sql/queries/select_album_recommendations_rediscover.sql
@@ -1,6 +1,6 @@
 -- Find albums with significant listening history that haven't been played recently
 -- Only considers albums with at least 2 tracks with listens
--- Parameters: :percentile (0.0 to 1.0), :filter_tracks (boolean), :track_uris (array)
+-- Parameters: percentile (0.0 to 1.0), filter_tracks (boolean)
 WITH album_stats AS (
     SELECT 
         t.album_uri,

--- a/data/sql/queries/select_artist_recommendations_rediscover.sql
+++ b/data/sql/queries/select_artist_recommendations_rediscover.sql
@@ -1,5 +1,5 @@
 -- Find artists with significant listening history that haven't been played recently
--- Parameters: :percentile (0.0 to 1.0), :filter_tracks (boolean), :track_uris (array)
+-- Parameters: percentile (0.0 to 1.0), filter_tracks (boolean)
 WITH artist_stats AS (
     SELECT 
         ta.artist_uri,

--- a/data/sql/queries/select_track_recommendations_jump_back_in.sql
+++ b/data/sql/queries/select_track_recommendations_jump_back_in.sql
@@ -1,6 +1,6 @@
 -- Find liked tracks with significant listening history that haven't been played recently
 -- Uses percentile to find tracks with above-average play counts
--- Parameters: :percentile (0.0 to 1.0), :filter_tracks (boolean), :track_uris (array)
+-- Parameters: percentile (0.0 to 1.0), filter_tracks (boolean)
 WITH track_stats AS (
     SELECT 
         s.track_uri,

--- a/data/sql/queries/select_track_recommendations_still_interested.sql
+++ b/data/sql/queries/select_track_recommendations_still_interested.sql
@@ -1,6 +1,6 @@
 -- Find liked tracks in the bottom 60% by streams that haven't been played recently
 -- Uses percentile to find tracks with below-average play counts
--- Parameters: :percentile (0.0 to 1.0) - typically 0.6 for bottom 60%, :filter_tracks (boolean), :track_uris (array)
+-- Parameters: percentile (0.0 to 1.0) - typically 0.6 for bottom 60%, filter_tracks (boolean)
 -- Note: Using <= with percentile 0.6 returns tracks at or below the 60th percentile (the bottom 60%)
 WITH track_stats AS (
     SELECT 

--- a/utils/ranking.py
+++ b/utils/ranking.py
@@ -2,8 +2,10 @@ import typing
 import pandas as pd
 import sqlalchemy
 
+from data.filters import filtered_connection
 from data.query import query_text
 from data.raw import get_connection, get_engine
+from routes.utils import to_json
 
 
 def track_ranks_over_time(track_uris: typing.Iterable[str], from_date, to_date):
@@ -61,17 +63,7 @@ def track_streams_by_month(track_uris, from_date, to_date):
         )
         results = cursor.fetchall()
 
-    out = {}
-    for track_uri, year, month, stream_count in results:
-        year = int(year)
-        month = int(month)
-        if track_uri not in out:
-            out[track_uri] = {}
-        if year not in out[track_uri]:
-            out[track_uri][year] = {}
-        if month not in out[track_uri][year]:
-            out[track_uri][year][month] = stream_count
-    return out
+    return _streams_by_month_dict(results, 0)
 
 
 def artist_streams_by_month(artist_uris, from_date, to_date):
@@ -88,17 +80,7 @@ def artist_streams_by_month(artist_uris, from_date, to_date):
         )
         results = cursor.fetchall()
 
-    out = {}
-    for artist_uri, year, month, stream_count in results:
-        year = int(year)
-        month = int(month)
-        if artist_uri not in out:
-            out[artist_uri] = {}
-        if year not in out[artist_uri]:
-            out[artist_uri][year] = {}
-        if month not in out[artist_uri][year]:
-            out[artist_uri][year][month] = stream_count
-    return out
+    return _streams_by_month_dict(results, 0)
 
 
 def album_streams_by_month(album_uris, from_date, to_date):
@@ -115,14 +97,121 @@ def album_streams_by_month(album_uris, from_date, to_date):
         )
         results = cursor.fetchall()
 
+    return _streams_by_month_dict(results, 0)
+
+
+# --- Filter-based variants (server-side top-N selection) ---
+
+def filtered_track_ranks_over_time(filters: dict, n: int = 10):
+    with filtered_connection(filters) as (conn, params):
+        return pd.read_sql_query(
+            sqlalchemy.text(query_text('filtered_track_ranks_over_time')),
+            conn,
+            params={
+                "from_date": params["wrapped_start_date"],
+                "to_date": params["wrapped_end_date"],
+                "n": n,
+            }
+        )
+
+
+def filtered_track_streams_by_month(filters: dict, n: int = 5):
+    with filtered_connection(filters) as (conn, params):
+        df = pd.read_sql_query(
+            sqlalchemy.text(query_text('filtered_track_streams_by_month')),
+            conn,
+            params={
+                "from_date": params["wrapped_start_date"],
+                "to_date": params["wrapped_end_date"],
+                "n": n,
+            }
+        )
+    return _streams_by_month_dict_from_df(df)
+
+
+def filtered_artist_ranks_over_time(filters: dict, n: int = 10):
+    with filtered_connection(filters) as (conn, params):
+        return pd.read_sql_query(
+            sqlalchemy.text(query_text('filtered_artist_ranks_over_time')),
+            conn,
+            params={
+                "from_date": params["wrapped_start_date"],
+                "to_date": params["wrapped_end_date"],
+                "n": n,
+            }
+        )
+
+
+def filtered_artist_streams_by_month(filters: dict, n: int = 5):
+    with filtered_connection(filters) as (conn, params):
+        df = pd.read_sql_query(
+            sqlalchemy.text(query_text('filtered_artist_streams_by_month')),
+            conn,
+            params={
+                "from_date": params["wrapped_start_date"],
+                "to_date": params["wrapped_end_date"],
+                "n": n,
+            }
+        )
+    return _streams_by_month_dict_from_df(df)
+
+
+def filtered_album_ranks_over_time(filters: dict, n: int = 10):
+    with filtered_connection(filters) as (conn, params):
+        return pd.read_sql_query(
+            sqlalchemy.text(query_text('filtered_album_ranks_over_time')),
+            conn,
+            params={
+                "from_date": params["wrapped_start_date"],
+                "to_date": params["wrapped_end_date"],
+                "n": n,
+            }
+        )
+
+
+def filtered_album_streams_by_month(filters: dict, n: int = 5):
+    with filtered_connection(filters) as (conn, params):
+        df = pd.read_sql_query(
+            sqlalchemy.text(query_text('filtered_album_streams_by_month')),
+            conn,
+            params={
+                "from_date": params["wrapped_start_date"],
+                "to_date": params["wrapped_end_date"],
+                "n": n,
+            }
+        )
+    return _streams_by_month_dict_from_df(df)
+
+
+def _streams_by_month_dict(results, uri_index):
+    """Convert raw cursor results (uri, year, month, count) to nested dict."""
     out = {}
-    for album_uri, year, month, stream_count in results:
-        year = int(year)
-        month = int(month)
-        if album_uri not in out:
-            out[album_uri] = {}
-        if year not in out[album_uri]:
-            out[album_uri][year] = {}
-        if month not in out[album_uri][year]:
-            out[album_uri][year][month] = stream_count
+    for row in results:
+        uri = row[uri_index]
+        year = int(row[1])
+        month = int(row[2])
+        stream_count = row[3]
+        if uri not in out:
+            out[uri] = {}
+        if year not in out[uri]:
+            out[uri][year] = {}
+        if month not in out[uri][year]:
+            out[uri][year][month] = stream_count
+    return out
+
+
+def _streams_by_month_dict_from_df(df):
+    """Convert a DataFrame with columns (uri, year, month, stream_count) to nested dict."""
+    out = {}
+    for _, row in df.iterrows():
+        uri = row.iloc[0]
+        year = int(row.iloc[1])
+        month = int(row.iloc[2])
+        stream_count = int(row.iloc[3])
+        if uri not in out:
+            out[uri] = {}
+        if year not in out[uri]:
+            out[uri][year] = {}
+        if month not in out[uri][year]:
+            out[uri][year][month] = stream_count
     return out


### PR DESCRIPTION
## Summary

Streaming history and streams-by-month endpoints can now accept the full filter set and determine the top-N entities server-side, instead of requiring the client to pre-sort and select top entities.

Currently, the client:
1. Fetches all tracks/artists/albums for the current filters
2. Sorts them by stream count
3. Picks top N (5 or 10)
4. Sends those URIs to streaming endpoints

With this change, the server handles the top-N selection internally using the filter set.

## Key changes

- **6 new SQL queries** (`filtered_*_ranks_over_time.sql` and `filtered_*_streams_by_month.sql`):
  - Use `matching_track_uris` temp table from PR #202
  - Select top-N entities by stream count within the filtered set (`LIMIT :n`)
  - Then compute history/monthly data for just those top-N
- **6 new Python functions** in `utils/ranking.py` (`filtered_{track,artist,album}_{ranks_over_time,streams_by_month}`)
- **Updated `app.py`** streaming routes: if no explicit entity URIs are provided, use the filter-based path with configurable `n` param

## Backward compatibility

Old interface (explicit URI lists) still works. The route handler checks: if `tracks`/`artists`/`albums` is present in the request, use the old path. Otherwise, use the new filtered path.

## Part of a series

1. PR #202 — Backend: all endpoints accept user-facing filters ✅
2. **This PR** — Backend: streaming endpoints accept filters + server-side top-N
3. Frontend: remove waterfall, all sections request in parallel