### PR TITLE
Frontend: remove request waterfall, all queries fire in parallel

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -237,49 +237,49 @@ export async function getTrackCredits(uri: string): Promise<Credit[]> {
 }
 
 export async function getPlaylists(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Record<string, Playlist>> {
   return sendRequest(`/api/playlists`, "playlists", filters);
 }
 
 export async function getArtists(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Record<string, Artist>> {
   return sendRequest(`/api/artists`, "artists", filters);
 }
 
 export async function getAlbums(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Record<string, Album>> {
   return sendRequest(`/api/albums`, "albums", filters);
 }
 
 export async function getLabels(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Label[]> {
   return sendRequest(`/api/labels`, "labels", filters);
 }
 
 export async function getGenres(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Genre[]> {
   return sendRequest(`/api/genres`, "genres", filters);
 }
 
 export async function getProducers(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Record<string, Producer>> {
   return sendRequest(`/api/producers`, "producers", filters);
 }
 
 export async function getReleaseYears(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<ReleaseYear[]> {
   return sendRequest(`/api/release-years`, "release years", filters);
 }
 
 export async function getTracksStreamingHistory(
-  filters: Pick<ActiveFilters, "tracks" | "wrapped">
+  filters: ActiveFilters & { n?: number }
 ): Promise<TrackRank[]> {
   return sendRequest(
     `/api/streams/tracks/history`,
@@ -289,7 +289,7 @@ export async function getTracksStreamingHistory(
 }
 
 export async function getArtistsStreamingHistory(
-  filters: Pick<ActiveFilters, "artists" | "wrapped">
+  filters: ActiveFilters & { n?: number }
 ): Promise<ArtistRank[]> {
   return sendRequest(
     `/api/streams/artists/history`,
@@ -299,7 +299,7 @@ export async function getArtistsStreamingHistory(
 }
 
 export async function getAlbumsStreamingHistory(
-  filters: Pick<ActiveFilters, "albums" | "wrapped">
+  filters: ActiveFilters & { n?: number }
 ): Promise<AlbumRank[]> {
   return sendRequest(
     `/api/streams/albums/history`,
@@ -309,7 +309,7 @@ export async function getAlbumsStreamingHistory(
 }
 
 export async function getTracksStreamsByMonth(
-  filters: Pick<ActiveFilters, "tracks" | "wrapped">
+  filters: ActiveFilters & { n?: number }
 ): Promise<StreamsByMonth> {
   return sendRequest(
     `/api/streams/tracks/months`,
@@ -319,7 +319,7 @@ export async function getTracksStreamsByMonth(
 }
 
 export async function getArtistsStreamsByMonth(
-  filters: Pick<ActiveFilters, "artists" | "wrapped">
+  filters: ActiveFilters & { n?: number }
 ): Promise<StreamsByMonth> {
   return sendRequest(
     `/api/streams/artists/months`,
@@ -329,7 +329,7 @@ export async function getArtistsStreamsByMonth(
 }
 
 export async function getAlbumsStreamsByMonth(
-  filters: Pick<ActiveFilters, "albums" | "wrapped">
+  filters: ActiveFilters & { n?: number }
 ): Promise<StreamsByMonth> {
   return sendRequest(
     `/api/streams/albums/months`,
@@ -346,7 +346,7 @@ export interface RecommendationList {
 export type Recommendations = Record<string, RecommendationList>;
 
 export async function getRecommendations(
-  filters: Pick<ActiveFilters, "tracks">
+  filters: ActiveFilters
 ): Promise<Recommendations> {
   return sendRequest(`/api/recommendations`, "recommendations", filters);
 }

--- a/client/src/charts/TracksStreamingHistoryStack.tsx
+++ b/client/src/charts/TracksStreamingHistoryStack.tsx
@@ -3,16 +3,16 @@ import { useState } from "react";
 import { Track } from "../api";
 import { ChartSkeleton } from "../design/ChartSkeleton";
 import { mostStreamedTracks } from "../sorting";
-import { useTracksCount, useTracksStreamsByMonth } from "../useApi";
+import { useTracksCount, useTracksStreamsByMonth, useTracks } from "../useApi";
 import styles from "./StreamingHistoryItem.module.css";
 import { StreamingHistoryStack } from "./StreamingHistoryStack";
 
 export function TracksStreamingHistoryStack() {
   const [n, setN] = useState(5);
   const { data: trackCount } = useTracksCount();
+  const { data: tracks } = useTracks();
   const {
     data: streamsByMonth,
-    tracks,
     shouldRender,
   } = useTracksStreamsByMonth(n);
 

--- a/client/src/useApi.ts
+++ b/client/src/useApi.ts
@@ -2,11 +2,17 @@ import { useQuery } from "@tanstack/react-query";
 
 import {
   ActiveFilters,
+  Album,
   AlbumRank,
+  Artist,
   ArtistCreditsData,
   ArtistRank,
   Credit,
   FilterOptions,
+  Genre,
+  Label,
+  Playlist,
+  Producer,
   getAlbums,
   getAlbumsStreamingHistory,
   getAlbumsStreamsByMonth,
@@ -26,17 +32,14 @@ import {
   getTracksStreamingHistory,
   getTracksStreamsByMonth,
   Recommendations,
+  ReleaseYear,
   searchTracks,
+  StreamsByMonth,
   toFiltersQuery,
   Track,
   TrackDetails,
   TrackRank,
 } from "./api";
-import {
-  mostStreamedAlbums,
-  mostStreamedArtists,
-  mostStreamedTracks,
-} from "./sorting";
 import { useFilters } from "./useFilters";
 import { countUniqueAsOfDates, countUniqueMonths } from "./utils";
 
@@ -96,11 +99,25 @@ export function useTrackCredits(uri: string) {
 }
 
 export function usePlaylists(filters?: ActiveFilters) {
-  return useTracksDependentQuery("playlists", getPlaylists, {}, filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<Record<string, Playlist>>({
+    ...defaultQueryOptions,
+    queryKey: ["playlists", query],
+    queryFn: async () => getPlaylists(activeFilters),
+  });
 }
 
 export function useArtists(filters?: ActiveFilters) {
-  return useTracksDependentQuery("artists", getArtists, {}, filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<Record<string, Artist>>({
+    ...defaultQueryOptions,
+    queryKey: ["artists", query],
+    queryFn: async () => getArtists(activeFilters),
+  });
 }
 
 export function useArtistCredits(artistUri: string) {
@@ -112,41 +129,67 @@ export function useArtistCredits(artistUri: string) {
 }
 
 export function useAlbums(filters?: ActiveFilters) {
-  return useTracksDependentQuery("albums", getAlbums, {}, filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<Record<string, Album>>({
+    ...defaultQueryOptions,
+    queryKey: ["albums", query],
+    queryFn: async () => getAlbums(activeFilters),
+  });
 }
 
 export function useLabels(filters?: ActiveFilters) {
-  return useTracksDependentQuery("labels", getLabels, [], filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<Label[]>({
+    ...defaultQueryOptions,
+    queryKey: ["labels", query],
+    queryFn: async () => getLabels(activeFilters),
+  });
 }
 
 export function useGenres(filters?: ActiveFilters) {
-  return useTracksDependentQuery("genres", getGenres, [], filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<Genre[]>({
+    ...defaultQueryOptions,
+    queryKey: ["genres", query],
+    queryFn: async () => getGenres(activeFilters),
+  });
 }
 
 export function useReleaseYears(filters?: ActiveFilters) {
-  return useTracksDependentQuery("release-years", getReleaseYears, [], filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<ReleaseYear[]>({
+    ...defaultQueryOptions,
+    queryKey: ["release-years", query],
+    queryFn: async () => getReleaseYears(activeFilters),
+  });
 }
 
 export function useProducers(filters?: ActiveFilters) {
-  return useTracksDependentQuery("producers", getProducers, {}, filters);
+  const globalFilters = useFilters();
+  const activeFilters = filters ?? globalFilters;
+  const query = toFiltersQuery(activeFilters) || DEFAULT_QUERY_KEY;
+  return useQuery<Record<string, Producer>>({
+    ...defaultQueryOptions,
+    queryKey: ["producers", query],
+    queryFn: async () => getProducers(activeFilters),
+  });
 }
 
 export function useTracksStreamingHistory() {
   const filters = useFilters();
-  const { data: tracks } = useTracks();
-
-  const topTenUris = Object.values(tracks ?? {})
-    .sort(mostStreamedTracks)
-    .slice(0, 10)
-    .map((t) => t.track_uri);
-
-  const tracksFilter = { tracks: topTenUris, wrapped: filters.wrapped };
-  const query = toFiltersQuery(tracksFilter);
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
   const result = useQuery<TrackRank[]>({
     ...defaultQueryOptions,
     queryKey: ["tracks-streaming-history", query],
-    enabled: !!tracks,
-    queryFn: async () => getTracksStreamingHistory(tracksFilter),
+    queryFn: async () => getTracksStreamingHistory({ ...filters, n: 10 }),
   });
 
   const shouldRender = !result.data || countUniqueAsOfDates(result.data) > 4;
@@ -156,20 +199,11 @@ export function useTracksStreamingHistory() {
 
 export function useArtistsStreamingHistory() {
   const filters = useFilters();
-  const { data: artists } = useArtists();
-
-  const topTenUris = Object.values(artists ?? {})
-    .sort(mostStreamedArtists)
-    .slice(0, 10)
-    .map((t) => t.artist_uri);
-
-  const artistsFilter = { artists: topTenUris, wrapped: filters.wrapped };
-  const query = toFiltersQuery(artistsFilter);
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
   const result = useQuery<ArtistRank[]>({
     ...defaultQueryOptions,
     queryKey: ["artists-streaming-history", query],
-    enabled: !!artists,
-    queryFn: async () => getArtistsStreamingHistory(artistsFilter),
+    queryFn: async () => getArtistsStreamingHistory({ ...filters, n: 10 }),
   });
 
   const shouldRender = !result.data || countUniqueAsOfDates(result.data) > 4;
@@ -179,20 +213,11 @@ export function useArtistsStreamingHistory() {
 
 export function useAlbumsStreamingHistory() {
   const filters = useFilters();
-  const { data: albums } = useAlbums();
-
-  const topTenUris = Object.values(albums ?? {})
-    .sort(mostStreamedAlbums)
-    .slice(0, 10)
-    .map((t) => t.album_uri);
-
-  const albumsFilter = { albums: topTenUris, wrapped: filters.wrapped };
-  const query = toFiltersQuery(albumsFilter);
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
   const result = useQuery<AlbumRank[]>({
     ...defaultQueryOptions,
     queryKey: ["albums-streaming-history", query],
-    enabled: !!albums,
-    queryFn: async () => getAlbumsStreamingHistory(albumsFilter),
+    queryFn: async () => getAlbumsStreamingHistory({ ...filters, n: 10 }),
   });
 
   const shouldRender = !result.data || countUniqueAsOfDates(result.data) > 4;
@@ -201,22 +226,13 @@ export function useAlbumsStreamingHistory() {
 }
 
 export function useTracksStreamsByMonth(n: number = 5) {
-  function getTopNTracksStreamsByMonth(
-    filters: ActiveFilters,
-    tracks: Record<string, Track>
-  ) {
-    const topNUris = Object.values(tracks ?? {})
-      .sort(mostStreamedTracks)
-      .slice(0, n)
-      .map((t) => t.track_uri);
-    return getTracksStreamsByMonth({ ...filters, tracks: topNUris });
-  }
-
-  const result = useTracksDependentQuery(
-    "tracks-streams-by-month-" + n,
-    getTopNTracksStreamsByMonth,
-    {}
-  );
+  const filters = useFilters();
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
+  const result = useQuery<StreamsByMonth>({
+    ...defaultQueryOptions,
+    queryKey: ["tracks-streams-by-month", query, n],
+    queryFn: async () => getTracksStreamsByMonth({ ...filters, n }),
+  });
 
   const shouldRender = !result.data || countUniqueMonths(result.data) > 3;
 
@@ -225,22 +241,11 @@ export function useTracksStreamsByMonth(n: number = 5) {
 
 export function useArtistsStreamsByMonth(n: number = 5) {
   const filters = useFilters();
-  const { data: artists } = useArtists();
-
-  const topNUris = Object.values(artists ?? {})
-    .sort(mostStreamedArtists)
-    .slice(0, n)
-    .map((t) => t.artist_uri);
-
-  const artistsFilter = { artists: topNUris, wrapped: filters.wrapped };
-  const query = toFiltersQuery(artistsFilter);
-  const result = useQuery<
-    Record<string, Record<number, Record<number, number>>>
-  >({
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
+  const result = useQuery<StreamsByMonth>({
     ...defaultQueryOptions,
     queryKey: ["artists-streams-by-month", query, n],
-    enabled: !!artists,
-    queryFn: async () => getArtistsStreamsByMonth(artistsFilter),
+    queryFn: async () => getArtistsStreamsByMonth({ ...filters, n }),
   });
 
   const shouldRender = !result.data || countUniqueMonths(result.data) > 3;
@@ -250,22 +255,11 @@ export function useArtistsStreamsByMonth(n: number = 5) {
 
 export function useAlbumsStreamsByMonth(n: number = 5) {
   const filters = useFilters();
-  const { data: albums } = useAlbums();
-
-  const topNUris = Object.values(albums ?? {})
-    .sort(mostStreamedAlbums)
-    .slice(0, n)
-    .map((t) => t.album_uri);
-
-  const albumsFilter = { albums: topNUris, wrapped: filters.wrapped };
-  const query = toFiltersQuery(albumsFilter);
-  const result = useQuery<
-    Record<string, Record<number, Record<number, number>>>
-  >({
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
+  const result = useQuery<StreamsByMonth>({
     ...defaultQueryOptions,
     queryKey: ["albums-streams-by-month", query, n],
-    enabled: !!albums,
-    queryFn: async () => getAlbumsStreamsByMonth(albumsFilter),
+    queryFn: async () => getAlbumsStreamsByMonth({ ...filters, n }),
   });
 
   const shouldRender = !result.data || countUniqueMonths(result.data) > 3;
@@ -275,63 +269,12 @@ export function useAlbumsStreamsByMonth(n: number = 5) {
 
 export function useRecommendations() {
   const filters = useFilters();
-  const query = toFiltersQuery({ wrapped: filters.wrapped, ...filters }) || DEFAULT_QUERY_KEY;
-
-  const { data: tracks, isSuccess } = useTracks(filters);
-  
-  // When no filters are applied, don't pass track URIs to avoid performance issues
-  // The server will handle unfiltered queries more efficiently without URIs
-  const hasFilters = Object.keys(filters).length > 0;
-  const tracksFilter = {
-    tracks: hasFilters ? (tracks ? Object.keys(tracks) : []) : undefined,
-    wrapped: filters.wrapped,
-  };
-
-  const result = useQuery<Recommendations>({
+  const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
+  return useQuery<Recommendations>({
     ...defaultQueryOptions,
-    enabled: isSuccess,
     queryKey: ["recommendations", query],
-    queryFn: async () =>
-      hasFilters && tracksFilter.tracks && tracksFilter.tracks.length === 0
-        ? {}
-        : getRecommendations(tracksFilter),
+    queryFn: async () => getRecommendations(filters),
   });
-
-  return { ...result, tracks };
-}
-
-function useTracksDependentQuery<T>(
-  key: string,
-  getValue: (
-    filters: ActiveFilters,
-    tracks: Record<string, Track>
-  ) => Promise<T>,
-  defaultValue: T,
-  filters?: ActiveFilters
-) {
-  const globalFilters = useFilters();
-  filters ??= globalFilters;
-  const query =
-    toFiltersQuery({ wrapped: filters.wrapped, ...filters }) ||
-    DEFAULT_QUERY_KEY;
-
-  const { data: tracks, isSuccess } = useTracks(filters);
-  const tracksFilter = {
-    tracks: tracks ? Object.keys(tracks) : [],
-    wrapped: filters.wrapped,
-  };
-
-  const result = useQuery<T>({
-    ...defaultQueryOptions,
-    enabled: isSuccess,
-    queryKey: [key, query],
-    queryFn: async () =>
-      tracksFilter.tracks.length === 0
-        ? defaultValue
-        : getValue(tracksFilter, tracks!),
-  });
-
-  return { ...result, tracks };
 }
 
 // If a piece of a query key is an empty string, the request will not fire

--- a/data/sql/queries/select_album_recommendations_rediscover.sql
+++ b/data/sql/queries/select_album_recommendations_rediscover.sql
@@ -1,6 +1,6 @@
 -- Find albums with significant listening history that haven't been played recently
 -- Only considers albums with at least 2 tracks with listens
--- Parameters: :percentile (0.0 to 1.0), :filter_tracks (boolean), :track_uris (array)
+-- Parameters: percentile (0.0 to 1.0), filter_tracks (boolean)
 WITH album_stats AS (
     SELECT 
         t.album_uri,

--- a/data/sql/queries/select_artist_recommendations_rediscover.sql
+++ b/data/sql/queries/select_artist_recommendations_rediscover.sql
@@ -1,5 +1,5 @@
 -- Find artists with significant listening history that haven't been played recently
--- Parameters: :percentile (0.0 to 1.0), :filter_tracks (boolean), :track_uris (array)
+-- Parameters: percentile (0.0 to 1.0), filter_tracks (boolean)
 WITH artist_stats AS (
     SELECT 
         ta.artist_uri,

--- a/data/sql/queries/select_track_recommendations_jump_back_in.sql
+++ b/data/sql/queries/select_track_recommendations_jump_back_in.sql
@@ -1,6 +1,6 @@
 -- Find liked tracks with significant listening history that haven't been played recently
 -- Uses percentile to find tracks with above-average play counts
--- Parameters: :percentile (0.0 to 1.0), :filter_tracks (boolean), :track_uris (array)
+-- Parameters: percentile (0.0 to 1.0), filter_tracks (boolean)
 WITH track_stats AS (
     SELECT 
         s.track_uri,

--- a/data/sql/queries/select_track_recommendations_still_interested.sql
+++ b/data/sql/queries/select_track_recommendations_still_interested.sql
@@ -1,6 +1,6 @@
 -- Find liked tracks in the bottom 60% by streams that haven't been played recently
 -- Uses percentile to find tracks with below-average play counts
--- Parameters: :percentile (0.0 to 1.0) - typically 0.6 for bottom 60%, :filter_tracks (boolean), :track_uris (array)
+-- Parameters: percentile (0.0 to 1.0) - typically 0.6 for bottom 60%, filter_tracks (boolean)
 -- Note: Using <= with percentile 0.6 returns tracks at or below the 60th percentile (the bottom 60%)
 WITH track_stats AS (
     SELECT 


### PR DESCRIPTION
## Summary

Eliminates the request waterfall where every section on the page was blocked behind `useTracks()` completing. All hooks now send `ActiveFilters` directly to the server and fire in parallel on mount.

### Before
```
useTracks() ──> wait ──> usePlaylists({tracks: [...]})
                    ──> useArtists({tracks: [...]})
                    ──> useAlbums({tracks: [...]})
                    ──> useLabels({tracks: [...]})
                    ──> ... (all blocked)
```

### After
```
useTracks()          ──> fires immediately
usePlaylists()       ──> fires immediately (sends filters)
useArtists()         ──> fires immediately (sends filters)
useAlbums()          ──> fires immediately (sends filters)
useLabels()          ──> fires immediately (sends filters)
useStreamingHistory()──> fires immediately (server picks top-N)
...
```

## Key changes

- **Removed `useTracksDependentQuery`** — the core waterfall helper
- **`usePlaylists`, `useArtists`, `useAlbums`, `useLabels`, `useGenres`, `useReleaseYears`, `useProducers`**: Send full `ActiveFilters` directly, no longer gated behind `useTracks()`
- **Streaming history hooks**: Send filters + `n=10`, server picks top-N entities
- **Streams-by-month hooks**: Send filters + `n`, server picks top-N entities
- **`useRecommendations`**: Sends filters directly
- **`api.ts`**: All `get*` functions accept full `ActiveFilters` instead of `Pick<ActiveFilters, 'tracks'>`
- **`TracksStreamingHistoryStack`**: Calls `useTracks()` independently (parallel, not serial)

## Part of a series

1. PR #202 — Backend: all endpoints accept user-facing filters ✅
2. PR #203 — Backend: streaming endpoints accept filters + server-side top-N ✅
3. **This PR** — Frontend: remove waterfall, all sections request in parallel