### PR TITLE
Simplify Track types and reduce page size

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -9,7 +9,7 @@ from routes.labels import labels_payload
 from routes.playlists import playlists_payload
 from routes.recommendations import recommendations_payload
 from routes.release_years import release_years_payload
-from routes.tracks import track_payload, tracks_search_payload, track_credits_payload
+from routes.tracks import tracks_search_payload, track_credits_payload
 from routes.utils import to_date_range, to_json
 from routes.producers import producers_payload
 from data.sql.migrations.migrations import perform_all_migrations
@@ -33,15 +33,9 @@ def get_filter_options():
     return filter_options_payload()
 
 
-@app.route("/api/tracks/search", methods = ['POST'])
-def search_tracks():
+@app.route("/api/tracks", methods = ['POST'])
+def list_tracks():
     return tracks_search_payload(request.json)
-
-
-@app.route("/api/tracks/<track_uri>")
-def get_track(track_uri):
-    min_date, max_date = to_date_range(request.args.get('wrapped', None))
-    return track_payload(track_uri, min_date, max_date)
 
 
 @app.route("/api/tracks/<track_uri>/credits")

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -8,7 +8,7 @@ export interface Playlist {
   playlist_track_count: number;
 }
 
-export interface TrackDetails extends Album {
+export interface Track extends Album {
   track_duration_ms: number;
   track_explicit: boolean;
   track_isrc: string;
@@ -22,17 +22,6 @@ export interface TrackDetails extends Album {
   artist_names: string[];
   artist_uris: string[];
 }
-
-export type Track = Pick<
-  TrackDetails,
-  | "track_uri"
-  | "track_name"
-  | "track_short_name"
-  | "track_stream_count"
-  | "track_last_played_at"
-  | "album_image_url"
-  | "album_release_date"
->;
 
 export interface TrackRank {
   track_uri: string;
@@ -227,20 +216,10 @@ export async function getArtistCredits(
   );
 }
 
-export async function searchTracks(
+export async function getTracks(
   filters: ActiveFilters & Partial<PaginationParams>
 ): Promise<PaginatedResponse<Track>> {
-  return sendRequest(`/api/tracks/search`, "tracks", filters);
-}
-
-export async function getTrack(
-  uri: string,
-  wrapped?: string
-): Promise<TrackDetails> {
-  return sendRequest(
-    `/api/tracks/${uri}${wrapped ? "?wrapped=" + wrapped : ""}`,
-    `track ${uri}`
-  );
+  return sendRequest(`/api/tracks`, "tracks", filters);
 }
 
 export async function getTrackCredits(uri: string): Promise<Credit[]> {

--- a/client/src/details/TrackDetails.tsx
+++ b/client/src/details/TrackDetails.tsx
@@ -12,12 +12,13 @@ import { TextSkeleton } from "../design/TextSkeleton";
 import { AlbumPill } from "../list-items/AlbumPill";
 import { ArtistPill } from "../list-items/ArtistPill";
 import sharedStyles from "../list-items/ListItems.module.css";
-import { useTrack, useTrackCredits } from "../useApi";
+import { useTracks, useTrackCredits } from "../useApi";
 import { formatDate } from "../utils";
 import styles from "./Details.module.css";
 
 export function TrackDetails({ trackURI }: { trackURI: string }) {
-  const { data: track } = useTrack(trackURI);
+  const { items: tracks } = useTracks({ filters: { tracks: [trackURI] } });
+  const track = tracks?.[0];
   const { data: credits } = useTrackCredits(trackURI);
 
   if (!track)

--- a/client/src/list-items/TrackRow.tsx
+++ b/client/src/list-items/TrackRow.tsx
@@ -3,25 +3,21 @@ import { IconHeart, IconHeartFilled } from "@tabler/icons-react";
 import clsx from "clsx";
 import { Fragment } from "react/jsx-runtime";
 
-import { TrackDetails } from "../api";
+import { Track } from "../api";
 import { KPIProps } from "../design/KPI";
-import { RowDesign, RowSkeleton } from "../design/RowDesign";
-import { useTrack } from "../useApi";
+import { RowDesign } from "../design/RowDesign";
 import { useSetFilters } from "../useFilters";
 import { useIsMobile } from "../useIsMobile";
 import sharedStyles from "./ListItems.module.css";
 
 interface TrackRowProps {
-  trackUri: string;
-  kpis?: (track: TrackDetails) => (KPIProps | null)[];
+  track: Track;
+  kpis?: (track: Track) => (KPIProps | null)[];
 }
 
-export function TrackRow({ trackUri, kpis }: TrackRowProps) {
+export function TrackRow({ track, kpis }: TrackRowProps) {
   const setFilters = useSetFilters();
-  const { data: track } = useTrack(trackUri);
   const isMobile = useIsMobile();
-
-  if (!track) return <RowSkeleton />;
 
   const stats = kpis
     ? kpis(track)
@@ -54,7 +50,7 @@ export function TrackRow({ trackUri, kpis }: TrackRowProps) {
       secondaryText={isMobile ? track.album_short_name : track.album_name}
       onClick={() =>
         setFilters({
-          tracks: [trackUri],
+          tracks: [track.track_uri],
         })
       }
       tertiaryText={

--- a/client/src/sections/RecommendationsSection.tsx
+++ b/client/src/sections/RecommendationsSection.tsx
@@ -90,7 +90,7 @@ function TrackRecommendations({ uris }: { uris: string[] }) {
       getKey={(track) => track.track_uri}
       renderRow={(track) => (
         <TrackRow
-          trackUri={track.track_uri}
+          track={track}
           kpis={(t) => [
             {
               label: "Last Played",

--- a/client/src/sections/TracksSection.tsx
+++ b/client/src/sections/TracksSection.tsx
@@ -94,7 +94,7 @@ function TracksDisplayGrid() {
       sort={sort}
       onSortChange={setSort}
       getKey={(track) => track.track_uri}
-      renderRow={(track) => <TrackRow trackUri={track.track_uri} />}
+      renderRow={(track) => <TrackRow track={track} />}
       hasNextPage={hasNextPage}
       isFetchingNextPage={isFetchingNextPage}
       onLoadMore={() => fetchNextPage()}

--- a/client/src/useApi.ts
+++ b/client/src/useApi.ts
@@ -23,15 +23,13 @@ import {
   getProducers,
   getRecommendations,
   getReleaseYears,
-  getTrack,
   getTrackCredits,
   getTracksStreamingHistory,
   getTracksStreamsByMonth,
+  getTracks,
   Recommendations,
-  searchTracks,
   StreamsByMonth,
   toFiltersQuery,
-  TrackDetails,
   TrackRank,
 } from "./api";
 import { useFilters } from "./useFilters";
@@ -40,7 +38,7 @@ import { countUniqueAsOfDates, countUniqueMonths } from "./utils";
 // If a piece of a query key is an empty string, the request will not fire
 const DEFAULT_QUERY_KEY = "DEFAULT";
 
-export const PAGE_SIZE = 10;
+export const PAGE_SIZE = 5;
 
 const defaultQueryOptions = {
   staleTime: 1000 * 60 * 60,
@@ -93,7 +91,7 @@ function useEntityQuery<T>(
 // --- Entity hooks ---
 
 export const useTracks = (opts?: EntityQueryOptions) =>
-  useEntityQuery("tracks", searchTracks, opts);
+  useEntityQuery("tracks", getTracks, opts);
 
 export const useArtists = (opts?: EntityQueryOptions) =>
   useEntityQuery("artists", getArtists, opts);
@@ -125,7 +123,7 @@ export function useTracksCount(filters?: ActiveFilters) {
   return useQuery({
     ...defaultQueryOptions,
     queryKey: ["tracks-count", query],
-    queryFn: async () => searchTracks(activeFilters),
+    queryFn: async () => getTracks(activeFilters),
     select: (data) => data.total,
   });
 }
@@ -137,15 +135,6 @@ export function useFilterOptions() {
     ...defaultQueryOptions,
     queryKey: ["filter-options"],
     queryFn: async () => getFilterOptions(),
-  });
-}
-
-export function useTrack(uri: string) {
-  const { wrapped } = useFilters();
-  return useQuery<TrackDetails>({
-    ...defaultQueryOptions,
-    queryKey: ["track", uri, wrapped],
-    queryFn: async () => getTrack(uri, wrapped),
   });
 }
 

--- a/data/provider.py
+++ b/data/provider.py
@@ -77,12 +77,6 @@ class DataProvider:
         self._initialized = True
 
 
-    def track(self, uri: str,
-              start_date: str = None,
-              end_date: str = None):
-        return self.tracks(uris={uri}, start_date=start_date, end_date=end_date).iloc[0]
-
-
     def tracks(self, 
                uris: typing.Iterable[str] = None, 
                liked: bool = None, 

--- a/routes/tracks.py
+++ b/routes/tracks.py
@@ -1,4 +1,3 @@
-import json
 import typing
 
 import pandas as pd
@@ -28,15 +27,7 @@ def tracks_search_payload(filters: typing.Mapping[str, str]):
         end_date=max_stream_date
     )
 
-    tracks = tracks[['track_uri', 'track_name', 'track_short_name', 'album_release_date', 'album_image_url', 'track_stream_count', 'track_last_played_at']]
-
     return paginate_df(tracks, filters, TRACK_SORT_COLUMNS, "Most streams")
-
-
-def track_payload(track_uri, min_date, max_date):
-    dp = DataProvider()
-    track = dp.track(track_uri, start_date=min_date, end_date=max_date)
-    return json.loads(track.to_json())
 
 
 def top_tracks(from_date, to_date):


### PR DESCRIPTION
- Merge `TrackDetails` into `Track` — the tracks endpoint now returns full objects
- Rename `/api/tracks/search` → `/api/tracks` (POST)
- Remove single-track `GET /api/tracks/<uri>` endpoint, `useTrack` hook, and `DataProvider.track()`
- `TrackRow` receives a `Track` object as prop instead of fetching per-row (eliminates N+1 requests)
- `TrackDetails` component uses `useTracks({ filters: { tracks: [uri] } })` instead of dedicated hook
- Reduce `PAGE_SIZE` from 10 to 5

Net -56 lines across 9 files.