### PR TITLE
Convert all API endpoints from POST to GET

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -12,6 +12,7 @@ from routes.release_years import release_years_payload
 from routes.tracks import tracks_search_payload, track_credits_payload
 from routes.utils import to_date_range, to_json
 from routes.producers import producers_payload
+from data.filters import parse_request_args
 from data.sql.migrations.migrations import perform_all_migrations
 from utils.ranking import album_ranks_over_time, album_streams_by_month, artist_ranks_over_time, artist_streams_by_month, track_ranks_over_time, track_streams_by_month
 from utils.ranking import filtered_track_ranks_over_time, filtered_track_streams_by_month, filtered_artist_ranks_over_time, filtered_artist_streams_by_month, filtered_album_ranks_over_time, filtered_album_streams_by_month
@@ -33,9 +34,9 @@ def get_filter_options():
     return filter_options_payload()
 
 
-@app.route("/api/tracks", methods = ['POST'])
+@app.route("/api/tracks")
 def list_tracks():
-    return tracks_search_payload(request.json)
+    return tracks_search_payload(parse_request_args(request.args))
 
 
 @app.route("/api/tracks/<track_uri>/credits")
@@ -43,14 +44,14 @@ def get_track_credits(track_uri):
     return track_credits_payload(track_uri)
 
 
-@app.route("/api/playlists", methods = ['POST'])
+@app.route("/api/playlists")
 def list_playlists():
-    return playlists_payload(request.json)
+    return playlists_payload(parse_request_args(request.args))
 
 
-@app.route("/api/artists", methods = ['POST'])
+@app.route("/api/artists")
 def list_artists():
-    return artists_payload(request.json)
+    return artists_payload(parse_request_args(request.args))
 
 
 @app.route("/api/artists/<artist_uri>/credits")
@@ -58,103 +59,109 @@ def get_artist_credits(artist_uri):
     return artist_credits_payload(artist_uri)
 
 
-@app.route("/api/albums", methods = ['POST'])
+@app.route("/api/albums")
 def list_albums():
-    return albums_payload(request.json)
+    return albums_payload(parse_request_args(request.args))
 
 
-@app.route("/api/labels", methods = ['POST'])
+@app.route("/api/labels")
 def list_labels():
-    return labels_payload(request.json)
+    return labels_payload(parse_request_args(request.args))
 
 
-@app.route("/api/genres", methods = ['POST'])
+@app.route("/api/genres")
 def list_genres():
-    return genres_payload(request.json)
+    return genres_payload(parse_request_args(request.args))
 
 
-@app.route("/api/producers", methods=['POST'])
+@app.route("/api/producers")
 def list_producers():
-    return producers_payload(request.json)
+    return producers_payload(parse_request_args(request.args))
 
 
-@app.route("/api/release-years", methods = ['POST'])
+@app.route("/api/release-years")
 def list_release_years():
-    return release_years_payload(request.json)
+    return release_years_payload(parse_request_args(request.args))
 
 
-@app.route("/api/streams/tracks/history", methods = ['POST'])
+@app.route("/api/streams/tracks/history")
 def list_track_stream_history():
-    n = request.json.get('n', 10)
-    track_uris = request.json.get('tracks', None)
+    params = parse_request_args(request.args)
+    n = params.get('n', 10)
+    track_uris = params.get('tracks', None)
     if track_uris is not None:
         if len(track_uris) == 0:
             return []
-        min_date, max_date = to_date_range(request.json.get('wrapped', None))
+        min_date, max_date = to_date_range(params.get('wrapped', None))
         return to_json(track_ranks_over_time(track_uris, min_date, max_date))
-    return to_json(filtered_track_ranks_over_time(request.json, n))
+    return to_json(filtered_track_ranks_over_time(params, n))
 
 
-@app.route("/api/streams/tracks/months", methods = ['POST'])
+@app.route("/api/streams/tracks/months")
 def list_track_streams_by_month():
-    n = request.json.get('n', 5)
-    track_uris = request.json.get('tracks', None)
+    params = parse_request_args(request.args)
+    n = params.get('n', 5)
+    track_uris = params.get('tracks', None)
     if track_uris is not None:
         if len(track_uris) == 0:
             return {}
-        min_date, max_date = to_date_range(request.json.get('wrapped', None))
+        min_date, max_date = to_date_range(params.get('wrapped', None))
         return track_streams_by_month(track_uris, min_date, max_date)
-    return filtered_track_streams_by_month(request.json, n)
+    return filtered_track_streams_by_month(params, n)
 
 
-@app.route("/api/streams/artists/history", methods = ['POST'])
+@app.route("/api/streams/artists/history")
 def list_artist_stream_history():
-    n = request.json.get('n', 10)
-    artist_uris = request.json.get('artists', None)
+    params = parse_request_args(request.args)
+    n = params.get('n', 10)
+    artist_uris = params.get('artists', None)
     if artist_uris is not None:
         if len(artist_uris) == 0:
             return []
-        min_date, max_date = to_date_range(request.json.get('wrapped', None))
+        min_date, max_date = to_date_range(params.get('wrapped', None))
         return to_json(artist_ranks_over_time(artist_uris, min_date, max_date))
-    return to_json(filtered_artist_ranks_over_time(request.json, n))
+    return to_json(filtered_artist_ranks_over_time(params, n))
 
 
-@app.route("/api/streams/artists/months", methods = ['POST'])
+@app.route("/api/streams/artists/months")
 def list_artist_streams_by_month():
-    n = request.json.get('n', 5)
-    artist_uris = request.json.get('artists', None)
+    params = parse_request_args(request.args)
+    n = params.get('n', 5)
+    artist_uris = params.get('artists', None)
     if artist_uris is not None:
         if len(artist_uris) == 0:
             return {}
-        min_date, max_date = to_date_range(request.json.get('wrapped', None))
+        min_date, max_date = to_date_range(params.get('wrapped', None))
         return artist_streams_by_month(artist_uris, min_date, max_date)
-    return filtered_artist_streams_by_month(request.json, n)
+    return filtered_artist_streams_by_month(params, n)
 
 
-@app.route("/api/streams/albums/history", methods = ['POST'])
+@app.route("/api/streams/albums/history")
 def list_album_stream_history():
-    n = request.json.get('n', 10)
-    album_uris = request.json.get('albums', None)
+    params = parse_request_args(request.args)
+    n = params.get('n', 10)
+    album_uris = params.get('albums', None)
     if album_uris is not None:
         if len(album_uris) == 0:
             return []
-        min_date, max_date = to_date_range(request.json.get('wrapped', None))
+        min_date, max_date = to_date_range(params.get('wrapped', None))
         return to_json(album_ranks_over_time(album_uris, min_date, max_date))
-    return to_json(filtered_album_ranks_over_time(request.json, n))
+    return to_json(filtered_album_ranks_over_time(params, n))
 
 
-@app.route("/api/streams/albums/months", methods = ['POST'])
+@app.route("/api/streams/albums/months")
 def list_album_streams_by_month():
-    n = request.json.get('n', 5)
-    album_uris = request.json.get('albums', None)
+    params = parse_request_args(request.args)
+    n = params.get('n', 5)
+    album_uris = params.get('albums', None)
     if album_uris is not None:
         if len(album_uris) == 0:
             return {}
-        min_date, max_date = to_date_range(request.json.get('wrapped', None))
+        min_date, max_date = to_date_range(params.get('wrapped', None))
         return album_streams_by_month(album_uris, min_date, max_date)
-    return filtered_album_streams_by_month(request.json, n)
+    return filtered_album_streams_by_month(params, n)
 
 
-@app.route("/api/recommendations", methods = ['POST'])
+@app.route("/api/recommendations")
 def get_recommendations():
-    return recommendations_payload(request.json)
+    return recommendations_payload(parse_request_args(request.args))

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -344,17 +344,15 @@ export async function getRecommendations(
 async function sendRequest<T>(
   url: string,
   dataName: string,
-  body?: Record<string, unknown> | (ActiveFilters & Partial<PaginationParams>)
+  params?: Record<string, unknown> | (ActiveFilters & Partial<PaginationParams>)
 ): Promise<T> {
   try {
-    const headers = body
-      ? new Headers({ "Content-Type": "application/json" })
-      : undefined;
-    const res = await fetch(url, {
-      method: body ? "POST" : "GET",
-      body: body ? JSON.stringify(body) : undefined,
-      headers,
-    });
+    let fullUrl = url;
+    if (params) {
+      const query = toQueryString(params);
+      if (query) fullUrl += `?${query}`;
+    }
+    const res = await fetch(fullUrl);
     if (!res.ok)
       throw new Error(
         `Error fetching ${dataName}: ${res.status}: ${res.statusText}`
@@ -366,6 +364,23 @@ async function sendRequest<T>(
       e instanceof Error ? e.message : `Error fetching ${dataName}`;
     throw new Error(message);
   }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toQueryString(params: Record<string, any>): string {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      if (value.length === 0) continue;
+      query.append(key, JSON.stringify(value));
+    } else if (typeof value === "boolean") {
+      if (value) query.append(key, "true");
+    } else {
+      query.append(key, String(value));
+    }
+  }
+  return query.toString();
 }
 
 const arrayKeys = [

--- a/data/filters.py
+++ b/data/filters.py
@@ -1,3 +1,4 @@
+import json
 import typing
 from contextlib import contextmanager
 
@@ -6,6 +7,34 @@ import sqlalchemy
 from data.query import query_text
 from data.raw import get_engine
 from routes.utils import to_date_range
+
+
+def parse_request_args(args) -> dict:
+    """Parse Flask request.args (query params) into the dict format payload functions expect.
+    
+    Array values are JSON-encoded strings in the query params.
+    """
+    result = {}
+    array_keys = ['tracks', 'playlists', 'artists', 'albums', 'labels', 'genres', 'producers', 'years']
+    for key in array_keys:
+        val = args.get(key, None)
+        if val is not None:
+            result[key] = json.loads(val)
+    
+    if args.get('liked'):
+        result['liked'] = True
+    if args.get('wrapped'):
+        result['wrapped'] = args.get('wrapped')
+    if args.get('n'):
+        result['n'] = int(args.get('n'))
+    if args.get('sort'):
+        result['sort'] = args.get('sort')
+    if args.get('limit'):
+        result['limit'] = int(args.get('limit'))
+    if args.get('offset'):
+        result['offset'] = int(args.get('offset'))
+    
+    return result
 
 
 def parse_filters(request_json: dict) -> dict:


### PR DESCRIPTION
Now that endpoints no longer receive thousands of track IDs in request bodies, we can use proper HTTP semantics.

**Changes:**
- All 14 POST endpoints converted to GET with query string parameters
- Added `parse_request_args()` helper in `data/filters.py` to parse query params (array values are JSON-encoded strings)
- Frontend `sendRequest()` now serializes params via `toQueryString()` instead of `JSON.stringify()` body
- No functional changes — same data, just GET instead of POST

3 files changed across backend and frontend.