### PR TITLE
Add show-less button to server-paginated display grids

### DIFF
--- a/client/src/design/DisplayGrid.tsx
+++ b/client/src/design/DisplayGrid.tsx
@@ -34,7 +34,6 @@ interface DisplayGridProps<T> {
   renderLargeTile?: (item: T) => JSX.Element;
   renderRow?: (item: T) => JSX.Element;
   renderPill?: (item: T) => JSX.Element;
-  hasNextPage?: boolean;
   isFetchingNextPage?: boolean;
   onLoadMore?: () => void;
 }
@@ -57,7 +56,6 @@ export function DisplayGrid<T>({
   renderRow,
   renderPill,
   getKey,
-  hasNextPage,
   isFetchingNextPage,
   onLoadMore,
 }: DisplayGridProps<T>) {
@@ -80,7 +78,11 @@ export function DisplayGrid<T>({
 
   const handleMore = () => {
     if (isServerPaginated) {
-      onLoadMore?.();
+      setCount((c) => c + PAGE_SIZE);
+      const allLoaded = items?.length ?? 0;
+      if (count + PAGE_SIZE > allLoaded) {
+        onLoadMore?.();
+      }
     } else {
       setCount((count) => count * 2);
     }
@@ -102,13 +104,11 @@ export function DisplayGrid<T>({
       value: "large-tile",
     });
 
-  const displayItems = isServerPaginated ? items : items?.slice(0, count);
+  const displayItems = items?.slice(0, count);
 
   const totalItems = total ?? items?.length ?? 0;
-  const showMore = isServerPaginated
-    ? (hasNextPage ?? false)
-    : count < totalItems;
-  const showLess = isServerPaginated ? false : count > PAGE_SIZE;
+  const showMore = count < totalItems;
+  const showLess = count > PAGE_SIZE;
 
   if (!loading && displayItems?.length === 0)
     return (

--- a/client/src/sections/AlbumsSection.tsx
+++ b/client/src/sections/AlbumsSection.tsx
@@ -93,7 +93,7 @@ export function AlbumsSection() {
 
 function AlbumsDisplayGrid() {
   const [sort, setSort] = useState("Most streams");
-  const { items, total, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
+  const { items, total, isLoading, fetchNextPage, isFetchingNextPage } =
     useAlbums({ sort, limit: PAGE_SIZE });
 
   return (
@@ -108,7 +108,7 @@ function AlbumsDisplayGrid() {
       renderTile={(album) => <AlbumTile album={album} />}
       renderLargeTile={(album) => <AlbumTile large album={album} />}
       renderRow={(album) => <AlbumRow album={album} />}
-      hasNextPage={hasNextPage}
+      
       isFetchingNextPage={isFetchingNextPage}
       onLoadMore={() => fetchNextPage()}
     />

--- a/client/src/sections/ArtistsSection.tsx
+++ b/client/src/sections/ArtistsSection.tsx
@@ -89,7 +89,7 @@ export function ArtistsSection() {
 
 function ArtistsDisplayGrid() {
   const [sort, setSort] = useState("Most streams");
-  const { items, total, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
+  const { items, total, isLoading, fetchNextPage, isFetchingNextPage } =
     useArtists({ sort, limit: PAGE_SIZE });
 
   return (
@@ -104,7 +104,7 @@ function ArtistsDisplayGrid() {
       renderTile={(artist) => <ArtistTile artist={artist} />}
       renderLargeTile={(artist) => <ArtistTile large artist={artist} />}
       renderRow={(artist) => <ArtistRow artist={artist} />}
-      hasNextPage={hasNextPage}
+      
       isFetchingNextPage={isFetchingNextPage}
       onLoadMore={() => fetchNextPage()}
     />

--- a/client/src/sections/GenresSection.tsx
+++ b/client/src/sections/GenresSection.tsx
@@ -19,7 +19,7 @@ export function GenresSection() {
 }
 
 function GenresDisplayGrid() {
-  const { items, total, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
+  const { items, total, isLoading, fetchNextPage, isFetchingNextPage } =
     useGenres({ sort: "Most liked tracks", limit: PAGE_SIZE });
 
   return (
@@ -29,7 +29,7 @@ function GenresDisplayGrid() {
       total={total}
       getKey={(gtc) => gtc.genre}
       renderPill={(gtc) => <GenrePill genre={gtc.genre} />}
-      hasNextPage={hasNextPage}
+      
       isFetchingNextPage={isFetchingNextPage}
       onLoadMore={() => fetchNextPage()}
     />

--- a/client/src/sections/LabelsSection.tsx
+++ b/client/src/sections/LabelsSection.tsx
@@ -19,7 +19,7 @@ export function LabelsSection() {
 }
 
 function LabelsDisplayGrid() {
-  const { items, total, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
+  const { items, total, isLoading, fetchNextPage, isFetchingNextPage } =
     useLabels({ sort: "Most liked tracks", limit: PAGE_SIZE });
 
   return (
@@ -29,7 +29,7 @@ function LabelsDisplayGrid() {
       total={total}
       getKey={(ltc) => ltc.label}
       renderPill={(ltc) => <RecordLabelPill label={ltc.label} />}
-      hasNextPage={hasNextPage}
+      
       isFetchingNextPage={isFetchingNextPage}
       onLoadMore={() => fetchNextPage()}
     />

--- a/client/src/sections/PlaylistsSection.tsx
+++ b/client/src/sections/PlaylistsSection.tsx
@@ -19,7 +19,7 @@ export function PlaylistsSection() {
 }
 
 function PlaylistsDisplayGrid() {
-  const { items, total, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
+  const { items, total, isLoading, fetchNextPage, isFetchingNextPage } =
     usePlaylists({ sort: "Most liked tracks", limit: PAGE_SIZE });
 
   return (
@@ -30,7 +30,7 @@ function PlaylistsDisplayGrid() {
       getKey={(playlist) => playlist.playlist_uri}
       renderTile={(playlist) => <PlaylistTile playlist={playlist} />}
       renderRow={(playlist) => <PlaylistRow playlist={playlist} />}
-      hasNextPage={hasNextPage}
+      
       isFetchingNextPage={isFetchingNextPage}
       onLoadMore={() => fetchNextPage()}
     />

--- a/client/src/sections/ProducersSection.tsx
+++ b/client/src/sections/ProducersSection.tsx
@@ -18,7 +18,7 @@ export function ProducersSection() {
 }
 
 function ProducersDisplayGrid() {
-  const { items, total, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
+  const { items, total, isLoading, fetchNextPage, isFetchingNextPage } =
     useProducers({ sort: "Most tracks", limit: PAGE_SIZE });
 
   return (
@@ -28,7 +28,7 @@ function ProducersDisplayGrid() {
       total={total}
       getKey={(producer) => producer.producer_mbid}
       renderPill={(producer) => <ProducerPill producer={producer} />}
-      hasNextPage={hasNextPage}
+      
       isFetchingNextPage={isFetchingNextPage}
       onLoadMore={() => fetchNextPage()}
     />

--- a/client/src/sections/ReleaseYearsSection.tsx
+++ b/client/src/sections/ReleaseYearsSection.tsx
@@ -18,7 +18,7 @@ export function ReleaseYearsSection() {
 }
 
 function YearsDisplayGrid() {
-  const { items, total, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
+  const { items, total, isLoading, fetchNextPage, isFetchingNextPage } =
     useReleaseYears({ sort: "Most liked tracks", limit: PAGE_SIZE });
 
   return (
@@ -28,7 +28,7 @@ function YearsDisplayGrid() {
       total={total}
       getKey={(yc) => "" + yc.release_year}
       renderPill={(yc) => <ReleaseYearPill year={yc.release_year} />}
-      hasNextPage={hasNextPage}
+      
       isFetchingNextPage={isFetchingNextPage}
       onLoadMore={() => fetchNextPage()}
     />

--- a/client/src/sections/TracksSection.tsx
+++ b/client/src/sections/TracksSection.tsx
@@ -82,7 +82,7 @@ export function TracksSection() {
 
 function TracksDisplayGrid() {
   const [sort, setSort] = useState("Most streams");
-  const { items, total, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
+  const { items, total, isLoading, fetchNextPage, isFetchingNextPage } =
     useTracks({ sort, limit: PAGE_SIZE });
 
   return (
@@ -95,7 +95,7 @@ function TracksDisplayGrid() {
       onSortChange={setSort}
       getKey={(track) => track.track_uri}
       renderRow={(track) => <TrackRow track={track} />}
-      hasNextPage={hasNextPage}
+      
       isFetchingNextPage={isFetchingNextPage}
       onLoadMore={() => fetchNextPage()}
     />


### PR DESCRIPTION
Restores the show-less button for all display grids, including server-paginated ones.

**Changes:**
- Track displayed item count client-side so show-less works for both client and server paginated grids
- Clicking show-less resets to PAGE_SIZE (5) items and scrolls the list top into view
- Clicking show-more on server-paginated grids increments display count and fetches the next page if needed
- Remove unused `hasNextPage` prop — show-more now derives from `count < totalItems`