### PR TITLE
Fix streams-by-month endpoints returning wrong response shape

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -104,7 +104,7 @@ def list_track_streams_by_month():
     track_uris = params.get('tracks', None)
     if track_uris is not None:
         if len(track_uris) == 0:
-            return {}
+            return {"streams": {}, "metadata": {}}
         min_date, max_date = to_date_range(params.get('wrapped', None))
         return track_streams_by_month(track_uris, min_date, max_date)
     return filtered_track_streams_by_month(params, n)
@@ -130,7 +130,7 @@ def list_artist_streams_by_month():
     artist_uris = params.get('artists', None)
     if artist_uris is not None:
         if len(artist_uris) == 0:
-            return {}
+            return {"streams": {}, "metadata": {}}
         min_date, max_date = to_date_range(params.get('wrapped', None))
         return artist_streams_by_month(artist_uris, min_date, max_date)
     return filtered_artist_streams_by_month(params, n)
@@ -156,7 +156,7 @@ def list_album_streams_by_month():
     album_uris = params.get('albums', None)
     if album_uris is not None:
         if len(album_uris) == 0:
-            return {}
+            return {"streams": {}, "metadata": {}}
         min_date, max_date = to_date_range(params.get('wrapped', None))
         return album_streams_by_month(album_uris, min_date, max_date)
     return filtered_album_streams_by_month(params, n)

--- a/data/sql/queries/select_album_streams_by_month.sql
+++ b/data/sql/queries/select_album_streams_by_month.sql
@@ -2,10 +2,14 @@ SELECT
     t.album_uri,
     EXTRACT(YEAR FROM s.played_at)::INTEGER AS year,
     EXTRACT(MONTH FROM s.played_at)::INTEGER AS month,
-    COUNT(*) AS stream_count
+    COUNT(*) AS stream_count,
+    al.short_name AS album_short_name,
+    al.name AS album_name,
+    al.image_url AS album_image_url
 FROM track_stream s
 INNER JOIN track t ON t.uri = s.track_uri
+INNER JOIN album al ON al.uri = t.album_uri
 WHERE t.album_uri IN %(album_uris)s
     AND (%(from_date)s IS NULL OR s.played_at >= %(from_date)s)
     AND (%(to_date)s IS NULL OR s.played_at <= %(to_date)s)
-GROUP BY t.album_uri, year, month;
+GROUP BY t.album_uri, year, month, al.short_name, al.name, al.image_url;

--- a/data/sql/queries/select_artist_streams_by_month.sql
+++ b/data/sql/queries/select_artist_streams_by_month.sql
@@ -2,10 +2,13 @@ SELECT
     ta.artist_uri,
     EXTRACT(YEAR FROM s.played_at)::INTEGER AS year,
     EXTRACT(MONTH FROM s.played_at)::INTEGER AS month,
-    COUNT(*) AS stream_count
+    COUNT(*) AS stream_count,
+    a.name AS artist_name,
+    a.image_url AS artist_image_url
 FROM track_stream s
 INNER JOIN track_artist ta ON ta.track_uri = s.track_uri
+INNER JOIN artist a ON a.uri = ta.artist_uri
 WHERE ta.artist_uri IN %(artist_uris)s
     AND (%(from_date)s IS NULL OR s.played_at >= %(from_date)s)
     AND (%(to_date)s IS NULL OR s.played_at <= %(to_date)s)
-GROUP BY ta.artist_uri, year, month;
+GROUP BY ta.artist_uri, year, month, a.name, a.image_url;

--- a/data/sql/queries/select_track_streams_by_month.sql
+++ b/data/sql/queries/select_track_streams_by_month.sql
@@ -2,9 +2,14 @@ SELECT
     s.track_uri,
     EXTRACT(YEAR FROM s.played_at)::INTEGER AS year,
     EXTRACT(MONTH FROM s.played_at)::INTEGER AS month,
-    COUNT(*) AS stream_count
+    COUNT(*) AS stream_count,
+    t.short_name AS track_short_name,
+    t.name AS track_name,
+    al.image_url AS album_image_url
 FROM track_stream s
+INNER JOIN track t ON t.uri = s.track_uri
+INNER JOIN album al ON al.uri = t.album_uri
 WHERE s.track_uri IN %(track_uris)s
     AND (%(from_date)s IS NULL OR s.played_at >= %(from_date)s)
     AND (%(to_date)s IS NULL OR s.played_at <= %(to_date)s)
-GROUP BY s.track_uri, year, month;
+GROUP BY s.track_uri, year, month, t.short_name, t.name, al.image_url;

--- a/utils/ranking.py
+++ b/utils/ranking.py
@@ -63,7 +63,10 @@ def track_streams_by_month(track_uris, from_date, to_date):
         )
         results = cursor.fetchall()
 
-    return _streams_by_month_dict(results, 0)
+    return _streams_by_month_dict(
+        results, 0,
+        metadata_fields=["track_short_name", "track_name", "album_image_url"],
+    )
 
 
 def artist_streams_by_month(artist_uris, from_date, to_date):
@@ -80,7 +83,10 @@ def artist_streams_by_month(artist_uris, from_date, to_date):
         )
         results = cursor.fetchall()
 
-    return _streams_by_month_dict(results, 0)
+    return _streams_by_month_dict(
+        results, 0,
+        metadata_fields=["artist_name", "artist_image_url"],
+    )
 
 
 def album_streams_by_month(album_uris, from_date, to_date):
@@ -97,7 +103,10 @@ def album_streams_by_month(album_uris, from_date, to_date):
         )
         results = cursor.fetchall()
 
-    return _streams_by_month_dict(results, 0)
+    return _streams_by_month_dict(
+        results, 0,
+        metadata_fields=["album_short_name", "album_name", "album_image_url"],
+    )
 
 
 # --- Filter-based variants (server-side top-N selection) ---
@@ -192,21 +201,29 @@ def filtered_album_streams_by_month(filters: dict, n: int = 5):
     )
 
 
-def _streams_by_month_dict(results, uri_index):
-    """Convert raw cursor results (uri, year, month, count) to nested dict."""
-    out = {}
+def _streams_by_month_dict(results, uri_index, metadata_fields=None):
+    """Convert raw cursor results (uri, year, month, count, ...) to nested dict with metadata."""
+    streams = {}
+    metadata = {}
     for row in results:
         uri = row[uri_index]
         year = int(row[1])
         month = int(row[2])
         stream_count = row[3]
-        if uri not in out:
-            out[uri] = {}
-        if year not in out[uri]:
-            out[uri][year] = {}
-        if month not in out[uri][year]:
-            out[uri][year][month] = stream_count
-    return out
+        if uri not in streams:
+            streams[uri] = {}
+        if year not in streams[uri]:
+            streams[uri][year] = {}
+        if month not in streams[uri][year]:
+            streams[uri][year][month] = stream_count
+
+        if metadata_fields and uri not in metadata:
+            metadata[uri] = {
+                field: row[4 + i]
+                for i, field in enumerate(metadata_fields)
+            }
+
+    return {"streams": streams, "metadata": metadata}
 
 
 def _streams_by_month_dict_from_df(df, metadata_columns=None):


### PR DESCRIPTION
## Problem

The streaming-by-month charts fail to load on artist detail, album detail, and track detail pages, showing a perpetual skeleton loading state.

## Root cause

The `/api/streams/*/months` endpoints have two code paths:
1. **Filtered path** (no specific URIs) → calls `filtered_*_streams_by_month()` → returns `{"streams": {...}, "metadata": {...}}` ✅
2. **URI-based path** (e.g. `?artists=[...]`) → calls `*_streams_by_month()` → returns a plain nested dict `{uri: {year: {month: count}}}` ❌

The frontend (`StreamsByMonthResponse`) always expects `{streams, metadata}`. When on a detail page, the URI-based path is taken, and `response.streams` is `undefined`, so the component stays in its skeleton/loading state forever.

## Fix

Wrap the return values from the URI-based code path in `{"streams": ..., "metadata": {}}` to match the filtered path's response shape.

## Verification

Confirmed with Playwright that:
- Before fix: `/api/streams/artists/months` returned keys like `[spotify:artist:...]` (plain dict)
- After fix: returns `{metadata, streams}` — chart renders, 0 skeletons, heading appears