### PR TITLE
Improve loading skeletons to match rendered content shapes

### DIFF
--- a/client/src/charts/AlbumsStreamingHistoryStack.tsx
+++ b/client/src/charts/AlbumsStreamingHistoryStack.tsx
@@ -1,16 +1,15 @@
 import { useState } from "react";
 
-import { ChartSkeleton } from "../design/ChartSkeleton";
 import { useAlbumsStreamsByMonth } from "../useApi";
 import styles from "./StreamingHistoryItem.module.css";
-import { StreamingHistoryStack } from "./StreamingHistoryStack";
+import { StreamingHistoryStack, StreamingHistoryStackSkeleton } from "./StreamingHistoryStack";
 import { totalStreams } from "./utils";
 
 export function AlbumsStreamingHistoryStack() {
   const [n, setN] = useState(5);
   const { data: response, shouldRender } = useAlbumsStreamsByMonth(n);
 
-  if (!response?.streams || !response?.metadata) return <ChartSkeleton />;
+  if (!response?.streams || !response?.metadata) return <StreamingHistoryStackSkeleton />;
 
   if (!shouldRender) return null;
 

--- a/client/src/charts/ArtistsStreamingHistoryStack.tsx
+++ b/client/src/charts/ArtistsStreamingHistoryStack.tsx
@@ -1,9 +1,8 @@
 import { useState } from "react";
 
-import { ChartSkeleton } from "../design/ChartSkeleton";
 import { useArtistsStreamsByMonth } from "../useApi";
 import styles from "./StreamingHistoryItem.module.css";
-import { StreamingHistoryStack } from "./StreamingHistoryStack";
+import { StreamingHistoryStack, StreamingHistoryStackSkeleton } from "./StreamingHistoryStack";
 import { totalStreams } from "./utils";
 
 export function ArtistsStreamingHistoryStack({
@@ -14,7 +13,7 @@ export function ArtistsStreamingHistoryStack({
   const [n, setN] = useState(5);
   const { data: response, shouldRender } = useArtistsStreamsByMonth(n);
 
-  if (!response?.streams || !response?.metadata) return <ChartSkeleton />;
+  if (!response?.streams || !response?.metadata) return <StreamingHistoryStackSkeleton />;
 
   if (!shouldRender) return null;
 

--- a/client/src/charts/StreamingHistoryStack.tsx
+++ b/client/src/charts/StreamingHistoryStack.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@mantine/core";
+import { Button, Skeleton } from "@mantine/core";
 import { IconMinus, IconPlus } from "@tabler/icons-react";
 import { useRef } from "react";
 
@@ -11,6 +11,32 @@ const xAxisHeight = 15;
 const individualMaxHeight = 250;
 const totalMinHeight = 600;
 const individualMinHeight = 120;
+const defaultSkeletonCount = 5;
+
+export function StreamingHistoryStackSkeleton() {
+  return (
+    <div className={styles.container}>
+      {Array.from({ length: defaultSkeletonCount }).map((_, i) => (
+        <div key={i}>
+          <div className={styles.itemHeader}>
+            <Skeleton
+              w={20}
+              h={20}
+              radius="sm"
+              style={{ display: "inline-block", marginRight: 8 }}
+            />
+            <Skeleton
+              w={120}
+              h={16}
+              style={{ display: "inline-block" }}
+            />
+          </div>
+          <Skeleton w="100%" h={individualMinHeight} />
+        </div>
+      ))}
+    </div>
+  );
+}
 
 export function StreamingHistoryStack<TItem>({
   data,

--- a/client/src/charts/TracksStreamingHistoryStack.tsx
+++ b/client/src/charts/TracksStreamingHistoryStack.tsx
@@ -1,9 +1,8 @@
 import { useState } from "react";
 
-import { ChartSkeleton } from "../design/ChartSkeleton";
 import { useTracksCount, useTracksStreamsByMonth } from "../useApi";
 import styles from "./StreamingHistoryItem.module.css";
-import { StreamingHistoryStack } from "./StreamingHistoryStack";
+import { StreamingHistoryStack, StreamingHistoryStackSkeleton } from "./StreamingHistoryStack";
 import { totalStreams } from "./utils";
 
 export function TracksStreamingHistoryStack() {
@@ -16,7 +15,7 @@ export function TracksStreamingHistoryStack() {
 
   if (!shouldRender) return null;
 
-  if (!response?.streams || !response?.metadata) return <ChartSkeleton />;
+  if (!response?.streams || !response?.metadata) return <StreamingHistoryStackSkeleton />;
 
   return (
     <>

--- a/client/src/design/KPI.tsx
+++ b/client/src/design/KPI.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@mantine/core";
+import { Skeleton, Text } from "@mantine/core";
 
 import styles from "./KPI.module.css";
 
@@ -12,6 +12,19 @@ export function KPIsList({ items }: { items: KPIProps[] }) {
     <div className={styles.kpisList}>
       {items.map((kpi) => (
         <KPI key={kpi.label} {...kpi} />
+      ))}
+    </div>
+  );
+}
+
+export function KPIsListSkeleton({ count = 4 }: { count?: number }) {
+  return (
+    <div className={styles.kpisList}>
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className={styles.kpi}>
+          <Skeleton w={60} h={14} mb={6} />
+          <Skeleton w={80} h={24} />
+        </div>
       ))}
     </div>
   );

--- a/client/src/design/RowDesign.tsx
+++ b/client/src/design/RowDesign.tsx
@@ -86,5 +86,20 @@ export function RowDesign({
 }
 
 export function RowSkeleton() {
-  return <Skeleton w={"100%"} h={80} />;
+  return (
+    <Paper className={styles.row}>
+      <div className={styles.rowContent}>
+        <Skeleton w={70} h={70} />
+        <div className={styles.rowText}>
+          <Skeleton w={160} h={16} mb={6} />
+          <Skeleton w={120} h={14} mb={4} />
+          <Skeleton w={80} h={12} />
+        </div>
+      </div>
+      <div className={styles.rowStats}>
+        <Skeleton w={50} h={30} />
+        <Skeleton w={50} h={30} />
+      </div>
+    </Paper>
+  );
 }

--- a/client/src/details/ArtistDetails.tsx
+++ b/client/src/details/ArtistDetails.tsx
@@ -2,8 +2,9 @@ import { Pill, Skeleton } from "@mantine/core";
 
 import { ArtistStreamsLineChart } from "../charts/ArtistsLineChart";
 import { ArtistsStreamingHistoryStack } from "../charts/ArtistsStreamingHistoryStack";
-import { KPIsList } from "../design/KPI";
+import { KPIsList, KPIsListSkeleton } from "../design/KPI";
 import { PillWithAvatar } from "../design/PillDesign";
+import { TextSkeleton } from "../design/TextSkeleton";
 import { ArtistPill } from "../list-items/ArtistPill";
 import { useAlbums, useArtistCredits, useArtists } from "../useApi";
 import { useSetFilters } from "../useFilters";
@@ -45,7 +46,16 @@ export function ArtistDetails({ artistURI }: ArtistDetailsProps) {
 
   const { data: artistCredits } = useArtistCredits(artistURI);
 
-  if (!artist) return null;
+  if (!artist)
+    return (
+      <>
+        <TextSkeleton style="h2" />
+        <div className={styles.artistImageContainer}>
+          <Skeleton w={200} h={200} circle style={{ margin: 16 }} />
+          <KPIsListSkeleton count={4} />
+        </div>
+      </>
+    );
 
   return (
     <>

--- a/client/src/details/PlaylistDetails.tsx
+++ b/client/src/details/PlaylistDetails.tsx
@@ -1,10 +1,19 @@
-import { KPIsList } from "../design/KPI";
+import { KPIsList, KPIsListSkeleton } from "../design/KPI";
+import { TextSkeleton } from "../design/TextSkeleton";
 import { usePlaylists } from "../useApi";
 import styles from "./Details.module.css";
 
 export function PlaylistDetails({ playlistURI }: { playlistURI: string }) {
   const { items: playlists } = usePlaylists({ filters: { playlists: [playlistURI] } });
-  if (!playlists) return null;
+  if (!playlists)
+    return (
+      <>
+        <TextSkeleton style="h2" />
+        <div className={styles.centered}>
+          <KPIsListSkeleton count={2} />
+        </div>
+      </>
+    );
 
   const playlist = playlists.find((p) => p.playlist_uri === playlistURI);
   if (!playlist) return null;

--- a/client/src/details/ProducerDetails.tsx
+++ b/client/src/details/ProducerDetails.tsx
@@ -1,3 +1,4 @@
+import { TextSkeleton } from "../design/TextSkeleton";
 import { ArtistTile } from "../list-items/ArtistTile";
 import { useArtists, useProducers } from "../useApi";
 import styles from "./Details.module.css";
@@ -8,7 +9,12 @@ export function ProducerDetails({ mbid }: { mbid: string }) {
   const { items: artists } = useArtists({
     filters: { artists: producer?.artist_uri ? [producer.artist_uri] : [] },
   });
-  if (!producers) return null;
+  if (!producers)
+    return (
+      <>
+        <TextSkeleton style="h2" />
+      </>
+    );
 
   const artist = producer?.artist_uri
     ? artists?.find((a) => a.artist_uri === producer.artist_uri)

--- a/client/src/details/TrackDetails.tsx
+++ b/client/src/details/TrackDetails.tsx
@@ -6,8 +6,7 @@ import { TrackStreamsLineChart } from "../charts/TracksLineChart";
 import { TracksStreamingHistoryStack } from "../charts/TracksStreamingHistoryStack";
 import { ArtistPills } from "../design/ArtistPills";
 import { ChartSkeleton } from "../design/ChartSkeleton";
-import { KPIsList } from "../design/KPI";
-import { RowSkeleton } from "../design/RowDesign";
+import { KPIsList, KPIsListSkeleton } from "../design/KPI";
 import { TextSkeleton } from "../design/TextSkeleton";
 import { AlbumPill } from "../list-items/AlbumPill";
 import { ArtistPill } from "../list-items/ArtistPill";
@@ -25,8 +24,8 @@ export function TrackDetails({ trackURI }: { trackURI: string }) {
     return (
       <>
         <TextSkeleton style="h2" />
-        <div className={styles.marginBottom}>
-          <RowSkeleton />
+        <div className={styles.centered}>
+          <KPIsListSkeleton count={7} />
         </div>
         <ChartSkeleton />
       </>


### PR DESCRIPTION
## Summary

Audited all loading skeleton states across the frontend and fixed mismatches between skeleton shapes and rendered content.

### Changes

**Skeleton shape improvements:**
- **RowSkeleton** — Updated from a flat bar to a layout matching the actual row: image circle + text lines + stats area
- **TrackDetails** — Replaced generic `RowSkeleton` with `KPIsListSkeleton count={7}` matching the 7 KPI items shown when loaded
- **StreamingHistoryStack** — Added new `StreamingHistoryStackSkeleton` with image+name header skeletons and chart bar placeholders (replaces generic `ChartSkeleton`)

**Missing skeleton additions:**
- **ArtistDetails** — Was returning `null` while loading; now shows h2 skeleton + 200px circular image skeleton + KPIs skeleton
- **PlaylistDetails** — Was returning `null` while loading; now shows h2 skeleton + 2-item KPIs skeleton
- **ProducerDetails** — Was returning `null` while loading; now shows h2 skeleton

**Cleanup:**
- Removed unused `ChartSkeleton` imports from all three streaming history stack components