### PR TITLE
Hide empty sections and bar charts with all-one values

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -82,6 +82,16 @@ Migrations run automatically at app startup via `perform_all_migrations()`.
 - Array query params are serialized as JSON strings (e.g., `artists=["spotify:artist:..."]`).
 - Import sorting is enforced by `eslint-plugin-simple-import-sort`.
 
+### Pull requests with UI changes
+
+When a PR includes visual changes, capture before/after screenshots using Playwright (configured as an MCP server in `.vscode/mcp.json`). Commit screenshots to `docs/screenshots/` on the PR branch.
+
+In the PR body, reference images using **HTML `<img>` tags** with `raw.githubusercontent.com` URLs and the commit SHA — not markdown `![]()`  syntax, which GitHub strips for these URLs:
+
+```html
+<img src="https://raw.githubusercontent.com/jbrown1618/spotify-stats/COMMIT_SHA/docs/screenshots/example.png" width="400">
+```
+
 ### Deployment
 
 - Production URL: https://spotify-stats-jbrown1618-96e348fdad70.herokuapp.com/

--- a/client/src/SectionTabs.tsx
+++ b/client/src/SectionTabs.tsx
@@ -14,7 +14,7 @@ import { ReactNode, useEffect, useState } from "react";
 
 import { ActiveFilters } from "./api";
 import styles from "./SectionTabs.module.css";
-import { useArtists } from "./useApi";
+import { useArtists, useRecommendations, useReleaseYears } from "./useApi";
 import { useFilters } from "./useFilters";
 
 interface SectionDef {
@@ -45,6 +45,9 @@ function hasDetails(f: ActiveFilters): boolean {
 
 export function useSectionDefs(sectionContent: Record<string, ReactNode>): SectionDef[] {
   const { total: artistCount } = useArtists({ sort: "Most streams", limit: 1 });
+  const { total: yearCount } = useReleaseYears({ sort: "Most liked tracks", limit: 1 });
+  const { data: recommendations, isLoading: recsLoading } = useRecommendations();
+  const hasRecommendations = recsLoading || (recommendations && Object.keys(recommendations).length > 0);
 
   return [
     {
@@ -107,14 +110,14 @@ export function useSectionDefs(sectionContent: Record<string, ReactNode>): Secti
       id: "years",
       label: "Years",
       icon: <IconCalendar size={20} />,
-      hidden: () => false,
+      hidden: () => yearCount <= 1,
       content: sectionContent.years,
     },
     {
       id: "recommendations",
       label: "For You",
       icon: <IconThumbUp size={20} />,
-      hidden: () => false,
+      hidden: () => !hasRecommendations,
       content: sectionContent.recommendations,
     },
   ];

--- a/client/src/charts/AlbumsBarChart.tsx
+++ b/client/src/charts/AlbumsBarChart.tsx
@@ -3,6 +3,7 @@ import { BarChart } from "@mantine/charts";
 import { ChartSkeleton } from "../design/ChartSkeleton";
 import { useAlbums } from "../useApi";
 import { useIsMobile } from "../useIsMobile";
+import { allBarValuesAreOne } from "./utils";
 
 export function AlbumsBarChart() {
   const isMobile = useIsMobile();
@@ -13,18 +14,22 @@ export function AlbumsBarChart() {
 
   if (!albums) return <ChartSkeleton />;
 
+  const data = albums
+    .map((p) => ({
+      Artist: p.album_short_name,
+      Liked: p.album_liked_track_count,
+      Unliked: p.album_track_count - p.album_liked_track_count,
+    }));
+
+  if (allBarValuesAreOne(data)) return null;
+
   const height = 100 + 30 * Math.min(maxCount, albums.length);
   return (
     <>
       <h3>Albums by liked tracks</h3>
       <BarChart
         h={height}
-        data={albums
-          .map((p) => ({
-            Artist: p.album_short_name,
-            Liked: p.album_liked_track_count,
-            Unliked: p.album_track_count - p.album_liked_track_count,
-          }))}
+        data={data}
         orientation="vertical"
         series={[
           { name: "Liked", color: "green" },

--- a/client/src/charts/ArtistsBarChart.tsx
+++ b/client/src/charts/ArtistsBarChart.tsx
@@ -3,6 +3,7 @@ import { BarChart } from "@mantine/charts";
 import { ChartSkeleton } from "../design/ChartSkeleton";
 import { useArtists } from "../useApi";
 import { useIsMobile } from "../useIsMobile";
+import { allBarValuesAreOne } from "./utils";
 
 export function ArtistsBarChart() {
   const isMobile = useIsMobile();
@@ -13,18 +14,22 @@ export function ArtistsBarChart() {
 
   if (!artists) return <ChartSkeleton />;
 
+  const data = artists
+    .map((p) => ({
+      Artist: p.artist_name,
+      Liked: p.artist_liked_track_count,
+      Unliked: p.artist_track_count - p.artist_liked_track_count,
+    }));
+
+  if (allBarValuesAreOne(data)) return null;
+
   const height = 100 + 30 * Math.min(maxCount, artists.length);
   return (
     <>
       <h3>Artists by liked tracks</h3>
       <BarChart
         h={height}
-        data={artists
-          .map((p) => ({
-            Artist: p.artist_name,
-            Liked: p.artist_liked_track_count,
-            Unliked: p.artist_track_count - p.artist_liked_track_count,
-          }))}
+        data={data}
         orientation="vertical"
         series={[
           { name: "Liked", color: "green" },

--- a/client/src/charts/GenresBarChart.tsx
+++ b/client/src/charts/GenresBarChart.tsx
@@ -3,6 +3,7 @@ import { BarChart } from "@mantine/charts";
 import { ChartSkeleton } from "../design/ChartSkeleton";
 import { useGenres } from "../useApi";
 import { useIsMobile } from "../useIsMobile";
+import { allBarValuesAreOne } from "./utils";
 
 export function GenresBarChart() {
   const { items: genres } = useGenres();
@@ -12,20 +13,24 @@ export function GenresBarChart() {
   if (!genres) return <ChartSkeleton />;
   if (genres && genres.length < 3) return null;
 
+  const data = genres
+    .sort((a, b) => b.liked_track_count - a.liked_track_count)
+    .slice(0, maxCount)
+    .map((p) => ({
+      Genre: p.genre,
+      Liked: p.liked_track_count,
+      Unliked: p.track_count - p.liked_track_count,
+    }));
+
+  if (allBarValuesAreOne(data)) return null;
+
   const height = 100 + 30 * Math.min(maxCount, genres.length);
   return (
     <>
       <h3>Top genres by liked tracks</h3>
       <BarChart
         h={height}
-        data={genres
-          .sort((a, b) => b.liked_track_count - a.liked_track_count)
-          .slice(0, maxCount)
-          .map((p) => ({
-            Genre: p.genre,
-            Liked: p.liked_track_count,
-            Unliked: p.track_count - p.liked_track_count,
-          }))}
+        data={data}
         orientation="vertical"
         series={[
           { name: "Liked", color: "green" },

--- a/client/src/charts/LabelsBarChart.tsx
+++ b/client/src/charts/LabelsBarChart.tsx
@@ -3,6 +3,7 @@ import { BarChart } from "@mantine/charts";
 import { ChartSkeleton } from "../design/ChartSkeleton";
 import { useLabels } from "../useApi";
 import { useIsMobile } from "../useIsMobile";
+import { allBarValuesAreOne } from "./utils";
 
 export function LabelsBarChart() {
   const { items: labels } = useLabels();
@@ -12,20 +13,24 @@ export function LabelsBarChart() {
 
   const maxCount = isMobile ? 15 : 20;
 
+  const data = labels
+    .sort((a, b) => b.liked_track_count - a.liked_track_count)
+    .slice(0, maxCount)
+    .map((p) => ({
+      Label: p.label,
+      Liked: p.liked_track_count,
+      Unliked: p.track_count - p.liked_track_count,
+    }));
+
+  if (allBarValuesAreOne(data)) return null;
+
   const height = 100 + 30 * Math.min(maxCount, labels.length);
   return (
     <>
       <h3>Top record labels by liked tracks</h3>
       <BarChart
         h={height}
-        data={labels
-          .sort((a, b) => b.liked_track_count - a.liked_track_count)
-          .slice(0, maxCount)
-          .map((p) => ({
-            Label: p.label,
-            Liked: p.liked_track_count,
-            Unliked: p.track_count - p.liked_track_count,
-          }))}
+        data={data}
         orientation="vertical"
         series={[
           { name: "Liked", color: "green" },

--- a/client/src/charts/PlaylistsBarChart.tsx
+++ b/client/src/charts/PlaylistsBarChart.tsx
@@ -3,6 +3,7 @@ import { BarChart } from "@mantine/charts";
 import { ChartSkeleton } from "../design/ChartSkeleton";
 import { usePlaylists } from "../useApi";
 import { useIsMobile } from "../useIsMobile";
+import { allBarValuesAreOne } from "./utils";
 
 export function PlaylistsBarChart() {
   const { items: playlists } = usePlaylists();
@@ -11,21 +12,26 @@ export function PlaylistsBarChart() {
   if (playlists && playlists.length < 3) return null;
 
   const maxCount = isMobile ? 15 : 20;
+
+  const data = playlists
+    .sort(
+      (a, b) => b.playlist_liked_track_count - a.playlist_liked_track_count
+    )
+    .slice(0, maxCount)
+    .map((p) => ({
+      Playlist: p.playlist_name,
+      Liked: p.playlist_liked_track_count,
+      Unliked: p.playlist_track_count - p.playlist_liked_track_count,
+    }));
+
+  if (allBarValuesAreOne(data)) return null;
+
   const height = 100 + 30 * Math.min(maxCount, playlists.length);
 
   return (
     <BarChart
       h={height}
-      data={playlists
-        .sort(
-          (a, b) => b.playlist_liked_track_count - a.playlist_liked_track_count
-        )
-        .slice(0, maxCount)
-        .map((p) => ({
-          Playlist: p.playlist_name,
-          Liked: p.playlist_liked_track_count,
-          Unliked: p.playlist_track_count - p.playlist_liked_track_count,
-        }))}
+      data={data}
       orientation="vertical"
       series={[
         { name: "Liked", color: "green" },

--- a/client/src/charts/ProducersBarChart.tsx
+++ b/client/src/charts/ProducersBarChart.tsx
@@ -3,6 +3,7 @@ import { BarChart } from "@mantine/charts";
 import { ChartSkeleton } from "../design/ChartSkeleton";
 import { useProducers } from "../useApi";
 import { useIsMobile } from "../useIsMobile";
+import { allBarValuesAreOne } from "./utils";
 
 export function ProducersBarChart() {
   const { items: producers } = useProducers();
@@ -12,20 +13,24 @@ export function ProducersBarChart() {
   if (!producers) return <ChartSkeleton />;
   if (producers && producers.length < 3) return null;
 
+  const data = producers
+    .sort((a, b) => b.liked_track_count - a.liked_track_count)
+    .slice(0, maxCount)
+    .map((p) => ({
+      Producer: p.producer_name,
+      Liked: p.liked_track_count,
+      Unliked: p.track_count - p.liked_track_count,
+    }));
+
+  if (allBarValuesAreOne(data)) return null;
+
   const height = 100 + 30 * Math.min(maxCount, producers.length);
   return (
     <>
       <h3>Top producers by liked tracks</h3>
       <BarChart
         h={height}
-        data={producers
-          .sort((a, b) => b.liked_track_count - a.liked_track_count)
-          .slice(0, maxCount)
-          .map((p) => ({
-            Producer: p.producer_name,
-            Liked: p.liked_track_count,
-            Unliked: p.track_count - p.liked_track_count,
-          }))}
+        data={data}
         orientation="vertical"
         series={[
           { name: "Liked", color: "green" },

--- a/client/src/charts/YearsBarChart.tsx
+++ b/client/src/charts/YearsBarChart.tsx
@@ -3,6 +3,7 @@ import { BarChart } from "@mantine/charts";
 import { ChartSkeleton } from "../design/ChartSkeleton";
 import { useReleaseYears } from "../useApi";
 import { useIsMobile } from "../useIsMobile";
+import { allBarValuesAreOne } from "./utils";
 
 export function YearsBarChart() {
   const { items: years } = useReleaseYears();
@@ -28,18 +29,22 @@ export function YearsBarChart() {
     }
   }
 
+  const data = yearItems
+    .sort((a, b) => (a.release_year > b.release_year ? 1 : -1))
+    .map((p) => ({
+      Year: p.release_year,
+      Liked: p.liked_track_count,
+      Unliked: p.track_count - p.liked_track_count,
+    }));
+
+  if (allBarValuesAreOne(data)) return null;
+
   return (
     <>
       <h3>Liked tracks by release year</h3>
       <BarChart
         h={500}
-        data={yearItems
-          .sort((a, b) => (a.release_year > b.release_year ? 1 : -1))
-          .map((p) => ({
-            Year: p.release_year,
-            Liked: p.liked_track_count,
-            Unliked: p.track_count - p.liked_track_count,
-          }))}
+        data={data}
         orientation="horizontal"
         series={[
           { name: "Liked", color: "green" },

--- a/client/src/charts/utils.ts
+++ b/client/src/charts/utils.ts
@@ -9,3 +9,10 @@ export function totalStreams(
     0
   );
 }
+
+/** Returns true if every entry in the bar chart data has a total value of 1 or less. */
+export function allBarValuesAreOne(
+  data: { Liked: number; Unliked: number }[]
+): boolean {
+  return data.length > 0 && data.every((d) => d.Liked + d.Unliked <= 1);
+}


### PR DESCRIPTION
## Changes

### Hide Years tab when only 1 year in data
Same pattern as artists tab — uses `useReleaseYears({ limit: 1 })` to get `total` and hides when `<= 1`.

### Hide For You tab when no recommendations
Calls `useRecommendations()` in `useSectionDefs` and hides the tab when the response is empty. Shows the tab while loading to avoid flash.

### Hide bar charts when all values are 1
New `allBarValuesAreOne()` utility in `charts/utils.ts`. Applied to all 7 bar chart components (Artists, Albums, Genres, Labels, Playlists, Producers, Years). Returns null when every entry has `Liked + Unliked <= 1` — a chart full of 1-bars isn't useful.

### Copilot instructions update
Added PR screenshot section documenting the HTML `<img>` tag approach with `raw.githubusercontent.com` URLs.
