### PR TITLE
Hide tracks tab when viewing a single track

### DIFF
--- a/client/src/SectionTabs.module.css
+++ b/client/src/SectionTabs.module.css
@@ -9,7 +9,6 @@
 .content {
     flex: 1;
     min-height: 0;
-    overflow-y: auto;
 }
 
 .tabBar {

--- a/client/src/SectionTabs.tsx
+++ b/client/src/SectionTabs.tsx
@@ -61,7 +61,7 @@ export function useSectionDefs(sectionContent: Record<string, ReactNode>): Secti
       id: "tracks",
       label: "Tracks",
       icon: <IconMusic size={20} />,
-      hidden: () => false,
+      hidden: (f) => f.tracks?.length === 1,
       content: sectionContent.tracks,
     },
     {


### PR DESCRIPTION
## Changes

### Hide tracks tab when viewing a single track
When a single track is filtered, the Tracks tab just shows that one track with its charts. Since TrackDetails already renders the streaming history and streams charts on the Details tab, the Tracks tab is redundant. Hides it when `filters.tracks?.length === 1`.

### Make header scroll with body content
Removed `overflow-y: auto` from the SectionTabs `.content` div so the page scrolls naturally instead of in an inner container.

### Make green header bar scroll with content  
The green `HeaderBackdrop` was inside the `position: fixed` Backdrop component, so it stayed pinned with the album tiles. Moved it out into the normal document flow so it scrolls away with the content.

## Screenshots (scroll behavior)

### At top of page
| Before (prod) | After |
|--------|-------|
| <img src="https://raw.githubusercontent.com/jbrown1618/spotify-stats/ff88373c68efe2c57866bdb8b0304959a3f2264c/docs/screenshots/top-before.png" width="400"> | <img src="https://raw.githubusercontent.com/jbrown1618/spotify-stats/ff88373c68efe2c57866bdb8b0304959a3f2264c/docs/screenshots/top-after.png" width="400"> |

### After scrolling down
| Before (green bar stays fixed) | After (green bar scrolled away) |
|--------|-------|
| <img src="https://raw.githubusercontent.com/jbrown1618/spotify-stats/ff88373c68efe2c57866bdb8b0304959a3f2264c/docs/screenshots/scrolled-before.png" width="400"> | <img src="https://raw.githubusercontent.com/jbrown1618/spotify-stats/ff88373c68efe2c57866bdb8b0304959a3f2264c/docs/screenshots/scrolled-after.png" width="400"> |

Note: The "after" screenshots show loading skeletons because the local dev server has no data cache yet. The key difference is visible in the scrolled state — the green bar is gone in "after" (scrolled away) but persists in "before" (fixed with backdrop).
