### PR TITLE
Hide Details tab for labels, genres, and years

### DIFF
--- a/client/src/SectionTabs.tsx
+++ b/client/src/SectionTabs.tsx
@@ -36,10 +36,7 @@ function hasDetails(f: ActiveFilters): boolean {
     f.artists?.length === 1 ||
     f.albums?.length === 1 ||
     f.playlists?.length === 1 ||
-    f.producers?.length === 1 ||
-    f.labels?.length === 1 ||
-    f.genres?.length === 1 ||
-    f.years?.length === 1
+    f.producers?.length === 1
   );
 }
 


### PR DESCRIPTION
## Problem

The Details tab was showing empty content when filtering by a single label, genre, or year — these entity types don't have detail components (`DetailsContent` only renders components for wrapped, track, artist, album, playlist, and producer).

## Audit

Ran a Playwright script against prod that systematically clicked every tab for each of the 9 filterable entity types. Found 4 cases of empty Details tabs:
- `single-label` → Details: empty
- `single-genre` → Details: empty
- `single-year` → Details: empty
- `single-producer` → Details: empty (edge case — producer without linked Spotify artist)

The first 3 are fixed by removing labels/genres/years from `hasDetails()`. The producer case is intermittent (some producers have linked artists, some don't) so it's left as-is for now.

All other filter × tab combinations render content correctly.

## Fix

Removed `labels`, `genres`, and `years` from the `hasDetails()` function in `SectionTabs.tsx`. The h2 title ("SM Entertainment", "k-pop", "Tracks released in 2024") still shows via `DetailsTitle` which has its own check.
