### PR TITLE
Replace more/less buttons with infinite scroll

### DIFF
--- a/client/src/SectionTabs.tsx
+++ b/client/src/SectionTabs.tsx
@@ -43,7 +43,7 @@ function hasDetails(f: ActiveFilters): boolean {
 export function useSectionDefs(sectionContent: Record<string, ReactNode>): SectionDef[] {
   const { total: artistCount } = useArtists({ sort: "Most streams", limit: 1 });
   const { total: albumCount } = useAlbums({ sort: "Most streams", limit: 1 });
-  const { total: yearCount } = useReleaseYears({ sort: "Most liked tracks", limit: 1 });
+  const { total: yearCount } = useReleaseYears({ sort: "Newest", limit: 1 });
   const { data: recommendations, isLoading: recsLoading } = useRecommendations();
   const hasRecommendations = recsLoading || (recommendations && Object.keys(recommendations).length > 0);
 
@@ -153,7 +153,10 @@ export function SectionTabs({ sections }: SectionTabsProps) {
           <button
             key={section.id}
             className={`${styles.tab} ${section.id === resolvedActiveId ? styles.tabActive : ""}`}
-            onClick={() => setActiveId(section.id)}
+            onClick={() => {
+              window.scrollTo({ top: 0 });
+              setActiveId(section.id);
+            }}
           >
             {section.icon}
             <span className={styles.tabLabel}>{section.label}</span>

--- a/client/src/design/DisplayGrid.module.css
+++ b/client/src/design/DisplayGrid.module.css
@@ -32,12 +32,9 @@
   flex-wrap: wrap;
 }
 
-.buttons {
+.sentinel {
   display: flex;
-  gap: 8px;
-  justify-content: flex-end;
-}
-
-.button {
-  margin-top: 16px;
+  justify-content: center;
+  padding: 16px 0;
+  min-height: 1px;
 }

--- a/client/src/design/DisplayGrid.tsx
+++ b/client/src/design/DisplayGrid.tsx
@@ -1,5 +1,5 @@
 import {
-  Button,
+  Loader,
   SegmentedControl,
   SegmentedControlItem,
   Select,
@@ -9,12 +9,10 @@ import {
   IconGridDots,
   IconLayoutGridFilled,
   IconList,
-  IconMinus,
   IconPill,
-  IconPlus,
 } from "@tabler/icons-react";
 import clsx from "clsx";
-import { useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import styles from "./DisplayGrid.module.css";
 import { LargeTileSkeleton } from "./LargeTileDesign";
@@ -59,7 +57,6 @@ export function DisplayGrid<T>({
   isFetchingNextPage,
   onLoadMore,
 }: DisplayGridProps<T>) {
-  const ref = useRef<HTMLDivElement>(null);
   const [variant, setVariant] = useState<DisplayVariant>(
     renderRow
       ? "row"
@@ -73,10 +70,17 @@ export function DisplayGrid<T>({
   );
 
   const isServerPaginated = !!onLoadMore;
-
   const [count, setCount] = useState(PAGE_SIZE);
 
-  const handleMore = () => {
+  const totalItems = total ?? items?.length ?? 0;
+  const hasMore = isServerPaginated
+    ? (items?.length ?? 0) < totalItems
+    : count < totalItems;
+
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const handleLoadMore = useCallback(() => {
+    if (isFetchingNextPage) return;
     if (isServerPaginated) {
       setCount((c) => c + PAGE_SIZE);
       const allLoaded = items?.length ?? 0;
@@ -84,14 +88,26 @@ export function DisplayGrid<T>({
         onLoadMore?.();
       }
     } else {
-      setCount((count) => count * 2);
+      setCount((c) => c + PAGE_SIZE);
     }
-  };
+  }, [isServerPaginated, isFetchingNextPage, items?.length, count, onLoadMore]);
 
-  const onLess = () => {
-    setCount(PAGE_SIZE);
-    ref.current?.scrollIntoView({ behavior: "smooth" });
-  };
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting && hasMore) {
+          handleLoadMore();
+        }
+      },
+      { rootMargin: "200px" }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, handleLoadMore]);
 
   const displayOptions: SegmentedControlItem[] = [];
   if (renderRow) displayOptions.push({ label: <IconList />, value: "row" });
@@ -106,10 +122,6 @@ export function DisplayGrid<T>({
 
   const displayItems = items?.slice(0, count);
 
-  const totalItems = total ?? items?.length ?? 0;
-  const showMore = count < totalItems;
-  const showLess = count > PAGE_SIZE;
-
   if (!loading && displayItems?.length === 0)
     return (
       <div className={styles.noData}>
@@ -119,7 +131,7 @@ export function DisplayGrid<T>({
 
   return (
     <>
-      <div ref={ref} className={styles.controls}>
+      <div className={styles.controls}>
         {displayOptions.length > 1 ? (
           <SegmentedControl
             onChange={(v) => setVariant(v as DisplayVariant)}
@@ -176,17 +188,9 @@ export function DisplayGrid<T>({
             </div>
           ))}
       </div>
-      <div className={styles.buttons}>
-        {showLess ? (
-          <Button variant="light" onClick={onLess} className={styles.button}>
-            <IconMinus />
-          </Button>
-        ) : null}
-        {showMore ? (
-          <Button variant="light" onClick={handleMore} className={styles.button}>
-            <IconPlus />
-          </Button>
-        ) : null}
+
+      <div ref={sentinelRef} className={styles.sentinel}>
+        {isFetchingNextPage && <Loader size="sm" />}
       </div>
     </>
   );

--- a/client/src/sections/ReleaseYearsSection.tsx
+++ b/client/src/sections/ReleaseYearsSection.tsx
@@ -1,10 +1,13 @@
 import { Pill } from "@mantine/core";
+import { useState } from "react";
 
 import { YearsBarChart } from "../charts/YearsBarChart";
 import { DisplayGrid } from "../design/DisplayGrid";
 import { useReleaseYears, PAGE_SIZE } from "../useApi";
 import { useSetFilters } from "../useFilters";
 import styles from "./Sections.module.css";
+
+const yearSortOptions = ["Newest", "Oldest", "Most liked tracks"];
 
 export function ReleaseYearsSection() {
   return (
@@ -18,14 +21,18 @@ export function ReleaseYearsSection() {
 }
 
 function YearsDisplayGrid() {
+  const [sort, setSort] = useState("Newest");
   const { items, total, isLoading, fetchNextPage, isFetchingNextPage } =
-    useReleaseYears({ sort: "Most liked tracks", limit: PAGE_SIZE });
+    useReleaseYears({ sort, limit: PAGE_SIZE });
 
   return (
     <DisplayGrid
       loading={isLoading}
       items={items}
       total={total}
+      sortOptions={yearSortOptions}
+      sort={sort}
+      onSortChange={setSort}
       getKey={(yc) => "" + yc.release_year}
       renderPill={(yc) => <ReleaseYearPill year={yc.release_year} />}
       

--- a/client/src/useApi.ts
+++ b/client/src/useApi.ts
@@ -38,7 +38,7 @@ import { countUniqueAsOfDates, countUniqueMonths } from "./utils";
 // If a piece of a query key is an empty string, the request will not fire
 const DEFAULT_QUERY_KEY = "DEFAULT";
 
-export const PAGE_SIZE = 5;
+export const PAGE_SIZE = 10;
 
 const defaultQueryOptions = {
   staleTime: 1000 * 60 * 60,

--- a/routes/pagination.py
+++ b/routes/pagination.py
@@ -42,6 +42,8 @@ GENRE_SORT_COLUMNS = {
 }
 
 RELEASE_YEAR_SORT_COLUMNS = {
+    "Newest": ("release_year", False),
+    "Oldest": ("release_year", True),
     "Most liked tracks": ("liked_track_count", False),
 }
 

--- a/routes/release_years.py
+++ b/routes/release_years.py
@@ -16,4 +16,4 @@ def release_years_payload(filters: dict):
     if years.empty:
         return {"items": [], "total": 0}
 
-    return paginate_df(years, filters, RELEASE_YEAR_SORT_COLUMNS, "Most liked tracks")
+    return paginate_df(years, filters, RELEASE_YEAR_SORT_COLUMNS, "Newest")


### PR DESCRIPTION
## Changes

- **Infinite scroll**: Replaced the +/- buttons on DisplayGrid with an IntersectionObserver sentinel that auto-loads more items as the user scrolls down. A loading spinner shows while fetching.
- **Larger page size**: Increased default from 5 to 10 items per page since grids are always at the bottom of a tab.
- **Scroll to top on tab change**: Prevents the observer from immediately triggering when switching tabs.
- **Years sort**: Default release years to reverse chronological (Newest). Added Newest/Oldest/Most liked tracks sort options to the years grid.