### PR TITLE
Add Spotify auth expiration banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,15 @@ script/dev-client
 ```
 
 And navigate to `http://localhost:5173`
+
+## Refresh Spotify authorization cache
+
+If Spotify authorization expires, run:
+
+```bash
+script/spotify-cache > spotify-cache.json
+```
+
+The script sends a Spotify request, runs the local authorization flow if needed,
+and writes the updated Spotipy cache JSON to stdout. Copy the file contents into
+the `SPOTIFY_CACHE` Heroku config var.

--- a/app/app.py
+++ b/app/app.py
@@ -14,6 +14,7 @@ from routes.utils import to_date_range, to_json
 from routes.producers import producers_payload
 from data.filters import parse_request_args
 from data.sql.migrations.migrations import perform_all_migrations
+from spotify.spotify_client import spotify_auth_status
 from utils.ranking import album_ranks_over_time, album_streams_by_month, artist_ranks_over_time, artist_streams_by_month, track_ranks_over_time, track_streams_by_month
 from utils.ranking import filtered_track_ranks_over_time, filtered_track_streams_by_month, filtered_artist_ranks_over_time, filtered_artist_streams_by_month, filtered_album_ranks_over_time, filtered_album_streams_by_month
 
@@ -32,6 +33,11 @@ def index():
 @app.route("/api/filters")
 def get_filter_options():
     return filter_options_payload()
+
+
+@app.route("/api/spotify-auth/status")
+def get_spotify_auth_status():
+    return spotify_auth_status()
 
 
 @app.route("/api/tracks")

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,6 +20,7 @@ import { RecommendationsSection } from "./sections/RecommendationsSection";
 import { ReleaseYearsSection } from "./sections/ReleaseYearsSection";
 import { TracksSection } from "./sections/TracksSection";
 import { SectionTabs, useSectionDefs } from "./SectionTabs";
+import { SpotifyAuthBanner } from "./SpotifyAuthBanner";
 import {
   useAlbums,
   useArtists,
@@ -156,6 +157,7 @@ export function App() {
       <Backdrop />
       <Container size="lg">
         <Header />
+        <SpotifyAuthBanner />
         <DetailsTitle />
         <SectionTabs sections={sections} />
       </Container>

--- a/client/src/SpotifyAuthBanner.tsx
+++ b/client/src/SpotifyAuthBanner.tsx
@@ -1,0 +1,30 @@
+import { Alert, Code } from "@mantine/core";
+
+import { useSpotifyAuthStatus } from "./useApi";
+
+const statusMessages = {
+  missing_cache:
+    "Spotify auth is not configured. Sync jobs need a refreshed Spotify cache before they can run.",
+  reauth_required:
+    "Spotify authorization has expired. Run the local cache refresh script and update the deployed Spotify cache before running sync jobs.",
+};
+
+export function SpotifyAuthBanner() {
+  const { data } = useSpotifyAuthStatus();
+
+  if (!data || data.status === "ok" || data.status === "error") {
+    return null;
+  }
+
+  const message = statusMessages[data.status];
+
+  return (
+    <Alert
+      color="yellow"
+      title="Spotify authorization needs attention"
+      mt="md"
+    >
+      {message} Cache refresh failures from Spotify return <Code>invalid_grant</Code>.
+    </Alert>
+  );
+}

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -211,8 +211,16 @@ export interface StreamsByMonthResponse {
   metadata: Record<string, Record<string, string>>;
 }
 
+export interface SpotifyAuthStatus {
+  status: "ok" | "missing_cache" | "reauth_required" | "error";
+}
+
 export async function getFilterOptions(): Promise<FilterOptions> {
   return sendRequest("/api/filters", "filter options");
+}
+
+export async function getSpotifyAuthStatus(): Promise<SpotifyAuthStatus> {
+  return sendRequest("/api/spotify-auth/status", "Spotify auth status");
 }
 
 export async function getArtistCredits(

--- a/client/src/useApi.ts
+++ b/client/src/useApi.ts
@@ -7,8 +7,6 @@ import {
   ArtistRank,
   Credit,
   FilterOptions,
-  PaginatedResponse,
-  PaginationParams,
   getAlbums,
   getAlbumsStreamingHistory,
   getAlbumsStreamsByMonth,
@@ -23,11 +21,15 @@ import {
   getProducers,
   getRecommendations,
   getReleaseYears,
+  getSpotifyAuthStatus,
   getTrackCredits,
+  getTracks,
   getTracksStreamingHistory,
   getTracksStreamsByMonth,
-  getTracks,
+  PaginatedResponse,
+  PaginationParams,
   Recommendations,
+  SpotifyAuthStatus,
   StreamsByMonthResponse,
   toFiltersQuery,
   TrackRank,
@@ -135,6 +137,16 @@ export function useFilterOptions() {
     ...defaultQueryOptions,
     queryKey: ["filter-options"],
     queryFn: async () => getFilterOptions(),
+  });
+}
+
+export function useSpotifyAuthStatus() {
+  return useQuery<SpotifyAuthStatus>({
+    queryKey: ["spotify-auth-status"],
+    queryFn: async () => getSpotifyAuthStatus(),
+    retry: false,
+    staleTime: 0,
+    gcTime: 1000 * 60,
   });
 }
 

--- a/script/refresh_spotify_cache.py
+++ b/script/refresh_spotify_cache.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+
+import spotipy
+from spotipy.oauth2 import SpotifyOauthError
+
+from spotify.spotify_client import get_spotify_auth_manager, spotify_cache_path
+
+
+def token_needs_reauthorization(error: SpotifyOauthError) -> bool:
+    return error.error == "invalid_grant"
+
+
+def authorize_with_spotify():
+    auth_manager = get_spotify_auth_manager()
+
+    try:
+        token_info = auth_manager.validate_token(
+            auth_manager.cache_handler.get_cached_token()
+        )
+    except SpotifyOauthError as e:
+        if not token_needs_reauthorization(e):
+            raise
+
+        print(
+            "Spotify refresh token is invalid; discarding local cache and reauthorizing.",
+            file=sys.stderr,
+        )
+        Path(spotify_cache_path).unlink(missing_ok=True)
+        auth_manager = get_spotify_auth_manager()
+        token_info = None
+
+    if token_info is None:
+        token_info = auth_manager.get_access_token(check_cache=False)
+
+    sp = spotipy.Spotify(
+        auth=token_info["access_token"],
+        requests_timeout=10,
+        retries=2,
+    )
+    user = sp.current_user()
+    print(f"Authorized Spotify user: {user['id']}", file=sys.stderr)
+
+
+def main():
+    authorize_with_spotify()
+
+    with open(spotify_cache_path) as f:
+        print(f.read())
+
+
+if __name__ == "__main__":
+    main()

--- a/script/spotify-cache
+++ b/script/spotify-cache
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+python -m script.refresh_spotify_cache

--- a/spotify/spotify_client.py
+++ b/spotify/spotify_client.py
@@ -1,22 +1,36 @@
 import os
 import spotipy
-from spotipy.oauth2 import SpotifyOAuth
+from spotipy.oauth2 import CacheFileHandler, SpotifyOAuth, SpotifyOauthError
 
 from utils.settings import spotify_cache, spotify_client_id, spotify_client_secret
 
-def get_spotify_client() -> spotipy.Spotify:
-    if not os.path.exists('.cache'):
+spotify_cache_path = ".cache"
+
+
+def ensure_spotify_cache_file():
+    if not os.path.exists(spotify_cache_path):
         cache = spotify_cache()
-        with open(".cache", "w") as f:
+        if cache is None:
+            return
+        with open(spotify_cache_path, "w") as f:
             f.write(cache)
 
+
+def get_spotify_auth_manager() -> SpotifyOAuth:
+    ensure_spotify_cache_file()
     auth_manager = SpotifyOAuth(
         client_id=spotify_client_id(),
         client_secret=spotify_client_secret(),
         redirect_uri="http://localhost:3000/",
         open_browser=False,
-        scope="user-library-read user-top-read user-read-recently-played playlist-read-collaborative"
+        scope="user-library-read user-top-read user-read-recently-played playlist-read-collaborative",
+        cache_handler=CacheFileHandler(cache_path=spotify_cache_path),
     )
+    return auth_manager
+
+
+def get_spotify_client() -> spotipy.Spotify:
+    auth_manager = get_spotify_auth_manager()
 
     sp = spotipy.Spotify(
         auth_manager=auth_manager,
@@ -25,3 +39,23 @@ def get_spotify_client() -> spotipy.Spotify:
     )
 
     return sp
+
+
+def spotify_auth_status() -> dict[str, str]:
+    auth_manager = get_spotify_auth_manager()
+    try:
+        token_info = auth_manager.cache_handler.get_cached_token()
+    except ValueError:
+        return {"status": "error"}
+
+    if token_info is None:
+        return {"status": "missing_cache"}
+
+    try:
+        auth_manager.validate_token(token_info)
+    except SpotifyOauthError as e:
+        if e.error == "invalid_grant":
+            return {"status": "reauth_required"}
+        return {"status": "error"}
+
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- add a Spotify auth status endpoint that detects missing cache or `invalid_grant` refresh failures
- show a top-page banner when Spotify auth needs attention before sync jobs can run
- add `script/spotify-cache` to refresh local Spotipy auth and print the updated cache JSON for `SPOTIFY_CACHE`

## Validation
- venv/bin/python -m py_compile spotify/spotify_client.py app/app.py script/refresh_spotify_cache.py
- npx eslint src/App.tsx src/api.ts src/useApi.ts src/SpotifyAuthBanner.tsx --quiet
- npm run build
- mocked auth status checks for missing cache, ok, and invalid_grant
- npm run lint -- --quiet (fails on pre-existing import-sort errors in unrelated files)
