### PR TITLE
Paginate For You recommendations with infinite scroll

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -442,19 +442,16 @@ export async function getGenresStreamShareByMonth(
   );
 }
 
-export interface PercentileRangeRecommendations {
-  uris: string[];
-}
-
 export async function getRecommendationsInRange(
   filters: ActiveFilters,
   low: number,
-  high: number
-): Promise<PercentileRangeRecommendations> {
+  high: number,
+  pagination?: Partial<PaginationParams>
+): Promise<PaginatedResponse<string>> {
   return sendRequest(
     `/api/recommendations/range`,
     "percentile range recommendations",
-    { ...filters, low, high }
+    { ...filters, low, high, ...pagination }
   );
 }
 

--- a/client/src/sections/RecommendationsSection.tsx
+++ b/client/src/sections/RecommendationsSection.tsx
@@ -10,10 +10,13 @@ import styles from "./Sections.module.css";
 export function RecommendationsSection() {
   const [range, setRange] = useState<[number, number]>([90, 100]);
   const [committedRange, setCommittedRange] = useState<[number, number]>(range);
-  const { data, isLoading } = useRecommendationsInRange(
-    committedRange[0],
-    committedRange[1]
-  );
+  const {
+    items: uris,
+    total,
+    isLoading,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useRecommendationsInRange(committedRange[0], committedRange[1]);
 
   return (
     <div>
@@ -29,17 +32,29 @@ export function RecommendationsSection() {
         onChangeEnd={setCommittedRange}
         className={styles.recommendationCard}
       />
-      <TrackRecommendations uris={data?.uris ?? []} loading={isLoading} />
+      <TrackRecommendations
+        uris={uris}
+        total={total}
+        loading={isLoading}
+        isFetchingNextPage={isFetchingNextPage}
+        onLoadMore={fetchNextPage}
+      />
     </div>
   );
 }
 
 function TrackRecommendations({
   uris,
+  total,
   loading,
+  isFetchingNextPage,
+  onLoadMore,
 }: {
   uris: string[];
+  total: number;
   loading?: boolean;
+  isFetchingNextPage?: boolean;
+  onLoadMore?: () => void;
 }) {
   const { items: allTracks, isLoading } = useTracks({ filters: { tracks: uris } });
 
@@ -52,6 +67,7 @@ function TrackRecommendations({
     <DisplayGrid
       loading={loading || isLoading}
       items={tracks}
+      total={total}
       getKey={(track) => track.track_uri}
       renderRow={(track) => (
         <TrackRow
@@ -66,6 +82,8 @@ function TrackRecommendations({
           ]}
         />
       )}
+      isFetchingNextPage={isFetchingNextPage}
+      onLoadMore={onLoadMore}
     />
   );
 }

--- a/client/src/useApi.ts
+++ b/client/src/useApi.ts
@@ -32,7 +32,6 @@ import {
   InsightsResponse,
   PaginatedResponse,
   PaginationParams,
-  PercentileRangeRecommendations,
   SpotifyAuthStatus,
   StreamsByMonthResponse,
   StreamShareMonth,
@@ -174,11 +173,28 @@ export function useArtistCredits(artistUri: string) {
 export function useRecommendationsInRange(low: number, high: number) {
   const filters = useFilters();
   const query = toFiltersQuery(filters) || DEFAULT_QUERY_KEY;
-  return useQuery<PercentileRangeRecommendations>({
+
+  const result = useInfiniteQuery<PaginatedResponse<string>>({
     ...defaultQueryOptions,
     queryKey: ["recommendations-range", query, low, high],
-    queryFn: async () => getRecommendationsInRange(filters, low, high),
+    queryFn: async ({ pageParam = 0 }) =>
+      getRecommendationsInRange(filters, low, high, {
+        limit: PAGE_SIZE,
+        offset: pageParam as number,
+      }),
+    initialPageParam: 0,
+    getNextPageParam: (_lastPage, allPages) => {
+      const total = allPages[0]?.total ?? 0;
+      const loaded = allPages.reduce((n, p) => n + p.items.length, 0);
+      return loaded < total ? loaded : undefined;
+    },
   });
+
+  return {
+    ...result,
+    items: result.data?.pages.flatMap((p) => p.items) ?? [],
+    total: result.data?.pages[0]?.total ?? 0,
+  };
 }
 
 export function useInsights() {

--- a/data/sql/queries/select_track_recommendations_percentile_range.sql
+++ b/data/sql/queries/select_track_recommendations_percentile_range.sql
@@ -26,5 +26,4 @@ FROM track_stats ts
 CROSS JOIN stream_percentiles sp
 WHERE ts.total_streams >= sp.low_streams
   AND ts.total_streams <= sp.high_streams
-ORDER BY ts.last_played ASC
-LIMIT 50;
+ORDER BY ts.last_played ASC;

--- a/routes/recommendations.py
+++ b/routes/recommendations.py
@@ -23,6 +23,9 @@ def _has_active_filters(params: dict) -> bool:
 def percentile_range_recommendations_payload(filters: dict, low_percentile: float, high_percentile: float):
     """Return tracks matching the current filter whose stream totals fall within
     [low_percentile, high_percentile] (each 0.0 to 1.0), sorted least-recently-streamed first.
+
+    Always returns a dict with 'items' (a page of track URIs) and 'total'.
+    If 'limit' is present in filters, slices to the requested page; otherwise returns all items.
     """
     if low_percentile > high_percentile:
         low_percentile, high_percentile = high_percentile, low_percentile
@@ -38,7 +41,7 @@ def percentile_range_recommendations_payload(filters: dict, low_percentile: floa
                 conn
             ).iloc[0]['cnt']
             if track_count < 60:
-                return {"uris": []}
+                return {"items": [], "total": 0}
 
         track_recs = pd.read_sql_query(
             sqlalchemy.text(query_text('select_track_recommendations_percentile_range')),
@@ -50,4 +53,12 @@ def percentile_range_recommendations_payload(filters: dict, low_percentile: floa
             }
         )
 
-    return {"uris": track_recs['track_uri'].tolist() if not track_recs.empty else []}
+    uris = track_recs['track_uri'].tolist() if not track_recs.empty else []
+    total = len(uris)
+
+    limit = filters.get('limit')
+    if limit is not None:
+        offset = filters.get('offset', 0)
+        uris = uris[offset:offset + limit]
+
+    return {"items": uris, "total": total}


### PR DESCRIPTION
## Summary

The "For You" tab track list now uses infinite scroll (10 items per page) instead of loading a flat batch of 20, matching the pattern already used by the Tracks tab.

## Changes

- **`data/sql/queries/select_track_recommendations_percentile_range.sql`**: removed the hardcoded `LIMIT 50`.
- **`routes/recommendations.py`**: `percentile_range_recommendations_payload` now honors `limit`/`offset` query params and returns `{"items": [...], "total": N}` instead of `{"uris": [...]}`.
- **`client/src/api.ts`**: `getRecommendationsInRange` accepts pagination params and returns `PaginatedResponse<string>`.
- **`client/src/useApi.ts`**: `useRecommendationsInRange` now uses `useInfiniteQuery` (page size 10) instead of a one-shot `useQuery`.
- **`client/src/sections/RecommendationsSection.tsx`**: wires `fetchNextPage`/`isFetchingNextPage`/`total` into `DisplayGrid`'s existing server-pagination support (`onLoadMore`), enabling the same infinite-scroll UX as the Tracks tab.

## Testing

- `npx tsc -b` — passes with no errors
- `npx eslint` on changed files — clean
- No automated test suite exists for this repo; DB-backed manual verification wasn't possible in this sandbox (no Postgres/venv available), but the implementation directly mirrors the already-working paginated pattern used by the Tracks tab (`useTracks`/`useEntityQuery`/`DisplayGrid`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>